### PR TITLE
[WF-531] Media Query utility

### DIFF
--- a/src/media-query/__tests__/__snapshots__/media-query.spec.ts.snap
+++ b/src/media-query/__tests__/__snapshots__/media-query.spec.ts.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`mediaQuery exposes media queries generated from breakpoints 1`] = `
+Object {
+  "large": "@media screen and (min-width: 1480px)",
+  "medium": "@media screen and (min-width: 820px)",
+  "small": "@media screen and (min-width: 480px)",
+}
+`;

--- a/src/media-query/__tests__/media-query.spec.ts
+++ b/src/media-query/__tests__/media-query.spec.ts
@@ -1,0 +1,7 @@
+import { mediaQuery } from '../index';
+
+describe('mediaQuery', () => {
+  it('exposes media queries generated from breakpoints', () => {
+    expect(mediaQuery).toMatchSnapshot();
+  });
+});

--- a/src/media-query/index.ts
+++ b/src/media-query/index.ts
@@ -1,0 +1,1 @@
+export { default as mediaQuery } from './media-query';

--- a/src/media-query/media-query.ts
+++ b/src/media-query/media-query.ts
@@ -1,0 +1,28 @@
+import { tokens } from '../tokens';
+
+type Breakpoints = typeof tokens.breakpoints;
+
+type Breakpoint = Breakpoints[keyof Breakpoints];
+
+type MediaQueries = {
+  readonly [key in keyof Breakpoints]: string;
+};
+
+function mediaQueryFromBreakpoint(breakpoint: Breakpoint) {
+  return `@media screen and (min-width: ${breakpoint})`;
+}
+
+function generatedMediaQueries(breakpoints: Breakpoints) {
+  return Object.keys(breakpoints).reduce((mediaQueries, breakpoint) => {
+    return {
+      ...mediaQueries,
+      [breakpoint]: mediaQueryFromBreakpoint(
+        breakpoints[breakpoint as keyof Breakpoints],
+      ),
+    };
+  }, {} as MediaQueries);
+}
+
+const mediaQuery = generatedMediaQueries(tokens.breakpoints);
+
+export default mediaQuery;

--- a/src/tokens/__tests__/__snapshots__/tokens.spec.ts.snap
+++ b/src/tokens/__tests__/__snapshots__/tokens.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`tokens preserve correct data structure 1`] = `
+exports[`tokens expose tokens generated based on JSON file compatible with Figma Tokens plugin 1`] = `
 Object {
   "borderRadius": Object {
     "circle": "50%",

--- a/src/tokens/__tests__/tokens.spec.ts
+++ b/src/tokens/__tests__/tokens.spec.ts
@@ -1,7 +1,7 @@
 import { tokens } from '../index';
 
 describe('tokens', () => {
-  it('preserve correct data structure', () => {
+  it('expose tokens generated based on JSON file compatible with Figma Tokens plugin', () => {
     expect(tokens).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
# [WF-531](https://datacamp.atlassian.net/browse/WF-531)

Implemented **media query utility** which returns list of media queries based on breakpoints from design tokens. Example of usage:

```js
import { mediaQuery } from '@datacamp/waffles/media-query';

const componentStyle = css`
  width: 100%;
  
  ${mediaQuery.medium} {
    width: auto;
  }
`;
```