### PR TITLE
[WF-532] New typography components

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -23,4 +23,5 @@ Cypress.Commands.add('a11yCheck', () => {
 
 Cypress.Commands.add('loadStory', (storyName: string) => {
   cy.visit(`stories/${storyName}`);
+  cy.injectAxe();
 });

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -1,2 +1,6 @@
 import 'cypress-axe';
 import './commands';
+
+afterEach(() => {
+  cy.a11yCheck();
+});

--- a/src/button/__tests__/button-full-width.story.tsx
+++ b/src/button/__tests__/button-full-width.story.tsx
@@ -19,7 +19,7 @@ function Story() {
       <div css={wrapperStyle}>
         {variants.map((variant) => {
           return (
-            <Button key={`${variant}`} variant={variant} fullWidth>
+            <Button key={variant} variant={variant} fullWidth>
               Full Width
             </Button>
           );
@@ -30,7 +30,7 @@ function Story() {
           return (
             <Button
               iconLeft={<AddCircle />}
-              key={`${variant}`}
+              key={variant}
               variant={variant}
               fullWidth
             >

--- a/src/button/__tests__/button-styled.story.tsx
+++ b/src/button/__tests__/button-styled.story.tsx
@@ -1,0 +1,23 @@
+import { css } from '@emotion/react';
+
+import { tokens } from '../../tokens';
+import { Button } from '../index';
+
+const wrapperStyle = css`
+  padding: ${tokens.spacing.medium};
+`;
+
+const customButtonStyle = css`
+  color: ${tokens.colors.redDarkText};
+  background-color: ${tokens.colors.yellowLight};
+`;
+
+function Story() {
+  return (
+    <div css={wrapperStyle}>
+      <Button css={customButtonStyle}>Button with Custom Styles</Button>
+    </div>
+  );
+}
+
+export default Story;

--- a/src/button/__tests__/button.e2e.ts
+++ b/src/button/__tests__/button.e2e.ts
@@ -1,60 +1,39 @@
 describe('Button', () => {
   it('renders as a basic button by default', () => {
     cy.loadStory('button-basic');
-    cy.injectAxe();
-
     cy.get('button').should('have.length', 1);
-    cy.a11yCheck();
   });
 
   it('renders proper focus state', () => {
     cy.loadStory('button-basic');
-    cy.injectAxe();
-
     cy.get('button').focus();
-    cy.a11yCheck();
   });
 
   it('renders with custom styles applied', () => {
     cy.loadStory('button-styled');
-    cy.injectAxe();
-
     cy.findByText('Button with Custom Styles').should('exist');
-    cy.a11yCheck();
   });
 
   it('renders as a link', () => {
     cy.loadStory('button-as-link');
-    cy.injectAxe();
-
     cy.get('a')
       .should('have.length', 1)
       .and('have.attr', 'href')
       .and('include', 'https://datacamp.com');
-    cy.a11yCheck();
   });
 
   it('render full width buttons', () => {
     cy.loadStory('button-full-width');
-    cy.injectAxe();
-
     cy.get('button').should('have.length', 8);
-    cy.a11yCheck();
   });
 
   it('render all varaints and sizes, when disabled and inverted', () => {
     cy.loadStory('button-variants-and-sizes');
-    cy.injectAxe();
-
     cy.get('button').should('have.length', 48);
-    cy.a11yCheck();
   });
 
   it('render all variants and sizes with various icons', () => {
     cy.loadStory('button-with-icons');
-    cy.injectAxe();
-
     cy.get('button').should('have.length', 51);
-    cy.a11yCheck();
   });
 });

--- a/src/button/__tests__/button.e2e.ts
+++ b/src/button/__tests__/button.e2e.ts
@@ -7,19 +7,19 @@ describe('Button', () => {
     cy.a11yCheck();
   });
 
-  it('renders with custom styles applied', () => {
-    cy.loadStory('button-styled');
-    cy.injectAxe();
-
-    cy.findByText('Button with Custom Styles').should('exist');
-    cy.a11yCheck();
-  });
-
   it('renders proper focus state', () => {
     cy.loadStory('button-basic');
     cy.injectAxe();
 
     cy.get('button').focus();
+    cy.a11yCheck();
+  });
+
+  it('renders with custom styles applied', () => {
+    cy.loadStory('button-styled');
+    cy.injectAxe();
+
+    cy.findByText('Button with Custom Styles').should('exist');
     cy.a11yCheck();
   });
 

--- a/src/button/__tests__/button.e2e.ts
+++ b/src/button/__tests__/button.e2e.ts
@@ -7,7 +7,7 @@ describe('Button', () => {
     cy.a11yCheck();
   });
 
-  it('renders button with custom styles applied', () => {
+  it('renders with custom styles applied', () => {
     cy.loadStory('button-styled');
     cy.injectAxe();
 

--- a/src/button/__tests__/button.e2e.ts
+++ b/src/button/__tests__/button.e2e.ts
@@ -7,6 +7,14 @@ describe('Button', () => {
     cy.a11yCheck();
   });
 
+  it('renders button with custom styles applied', () => {
+    cy.loadStory('button-styled');
+    cy.injectAxe();
+
+    cy.findByText('Button with Custom Styles');
+    cy.a11yCheck();
+  });
+
   it('renders proper focus state', () => {
     cy.loadStory('button-basic');
     cy.injectAxe();

--- a/src/button/__tests__/button.e2e.ts
+++ b/src/button/__tests__/button.e2e.ts
@@ -11,7 +11,7 @@ describe('Button', () => {
     cy.loadStory('button-styled');
     cy.injectAxe();
 
-    cy.findByText('Button with Custom Styles');
+    cy.findByText('Button with Custom Styles').should('exist');
     cy.a11yCheck();
   });
 

--- a/src/button/button.tsx
+++ b/src/button/button.tsx
@@ -1,17 +1,8 @@
-/* eslint-disable react/display-name */
 import React, { forwardRef } from 'react';
 import { useFocusRing } from '@react-aria/focus';
 
+import type { PolymorphicRef, PolymorphicComponentProps } from '../utils';
 import { buttonStyle, innerContentStyle } from './styles';
-
-type ElementRef<T extends React.ElementType> =
-  React.ComponentPropsWithRef<T>['ref'];
-
-type MergeElementPropsWithRef<
-  T extends React.ElementType,
-  P extends Record<string, unknown>,
-> = Omit<React.ComponentPropsWithoutRef<T>, keyof P> &
-  P & { ref?: ElementRef<T> };
 
 type ButtonBaseProps = {
   variant?: 'primary' | 'secondary' | 'plain' | 'destructive';
@@ -36,9 +27,8 @@ type ButtonNoIconProps = {
   'aria-label'?: string;
 } & ButtonBaseProps;
 
-type ButtonProps<T extends React.ElementType = 'button'> = {
-  as?: T;
-} & MergeElementPropsWithRef<T, ButtonNoIconProps | ButtonIconOnlyProps>;
+type ButtonProps<T extends React.ElementType = 'button'> =
+  PolymorphicComponentProps<T, ButtonNoIconProps | ButtonIconOnlyProps>;
 
 type ButtonComponent = <T extends React.ElementType = 'button'>(
   props: ButtonProps<T>,
@@ -57,7 +47,7 @@ function ButtonBase<T extends React.ElementType = 'button'>(
     children,
     ...restProps
   }: ButtonProps<T>,
-  ref?: ElementRef<T>,
+  ref?: PolymorphicRef<T>,
 ) {
   const Element = as || 'button';
 

--- a/src/button/styles.ts
+++ b/src/button/styles.ts
@@ -20,7 +20,7 @@ const sizeMap = {
     sizing: tokens.sizing.large,
     spacing: tokens.spacing.medium,
   },
-};
+} as const;
 
 const regularVariantMap = {
   primary: {

--- a/src/chapeau/__tests__/__snapshots__/chapeau.spec.tsx.snap
+++ b/src/chapeau/__tests__/__snapshots__/chapeau.spec.tsx.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Chapeau renders snapshot 1`] = `
+.emotion-0 {
+  color: #05192D;
+  font-family: Studio-Feixen-Sans,Arial,sans-serif;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 1;
+  margin: 0;
+  padding: 0;
+  font-size: 12px;
+  font-weight: 800;
+  line-height: 1.25;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+}
+
+<p
+  class="emotion-0"
+>
+  Test
+</p>
+`;

--- a/src/chapeau/__tests__/chapeau-basic.story.tsx
+++ b/src/chapeau/__tests__/chapeau-basic.story.tsx
@@ -1,0 +1,22 @@
+import { css } from '@emotion/react';
+
+import { tokens } from '../../tokens';
+import { Heading } from '../../heading';
+import { Chapeau } from '../index';
+
+const wrapperStyle = css`
+  padding: ${tokens.spacing.medium};
+`;
+
+function Story() {
+  return (
+    <section css={wrapperStyle}>
+      <header>
+        <Chapeau>Short title above heading</Chapeau>
+        <Heading size="xxlarge">Most important page heading</Heading>
+      </header>
+    </section>
+  );
+}
+
+export default Story;

--- a/src/chapeau/__tests__/chapeau-styled.story.tsx
+++ b/src/chapeau/__tests__/chapeau-styled.story.tsx
@@ -1,0 +1,26 @@
+import { css } from '@emotion/react';
+
+import { tokens } from '../../tokens';
+import { Heading } from '../../heading';
+import { Chapeau } from '../index';
+
+const wrapperStyle = css`
+  padding: ${tokens.spacing.medium};
+`;
+
+const chapeauStyle = css`
+  color: ${tokens.colors.greenDarkText};
+`;
+
+function Story() {
+  return (
+    <section css={wrapperStyle}>
+      <header>
+        <Chapeau css={chapeauStyle}>Chapeau with custom styles</Chapeau>
+        <Heading size="xxlarge">Most important page heading</Heading>
+      </header>
+    </section>
+  );
+}
+
+export default Story;

--- a/src/chapeau/__tests__/chapeau.e2e.ts
+++ b/src/chapeau/__tests__/chapeau.e2e.ts
@@ -1,17 +1,11 @@
 describe('Chapeau', () => {
   it('renders a basic text', () => {
     cy.loadStory('chapeau-basic');
-    cy.injectAxe();
-
     cy.findByText('Short title above heading').should('exist');
-    cy.a11yCheck();
   });
 
   it('renders with custom styles applied', () => {
     cy.loadStory('chapeau-styled');
-    cy.injectAxe();
-
     cy.get('main').find('p').should('have.length', 1);
-    cy.a11yCheck();
   });
 });

--- a/src/chapeau/__tests__/chapeau.e2e.ts
+++ b/src/chapeau/__tests__/chapeau.e2e.ts
@@ -1,0 +1,17 @@
+describe('Chapeau', () => {
+  it('renders a basic text', () => {
+    cy.loadStory('chapeau-basic');
+    cy.injectAxe();
+
+    cy.findByText('Short title above heading').should('exist');
+    cy.a11yCheck();
+  });
+
+  it('renders with custom styles applied', () => {
+    cy.loadStory('chapeau-styled');
+    cy.injectAxe();
+
+    cy.get('main').find('p').should('have.length', 1);
+    cy.a11yCheck();
+  });
+});

--- a/src/chapeau/__tests__/chapeau.spec.tsx
+++ b/src/chapeau/__tests__/chapeau.spec.tsx
@@ -1,0 +1,23 @@
+import { render } from '@testing-library/react';
+
+import { Chapeau } from '../index';
+
+describe('Chapeau', () => {
+  it('renders a paragraph containing the text', () => {
+    const { container } = render(<Chapeau>Taylor Swift Anniversary</Chapeau>);
+
+    const chapeau = container.querySelector('p');
+
+    expect(chapeau).toBeInTheDocument();
+    expect(chapeau).toHaveTextContent('Taylor Swift Anniversary');
+  });
+
+  it('renders snapshot', () => {
+    const { getByText } = render(<Chapeau>Test</Chapeau>);
+
+    const chapeau = getByText('Test');
+
+    expect(chapeau).toBeInTheDocument();
+    expect(chapeau).toMatchSnapshot();
+  });
+});

--- a/src/chapeau/chapeau.tsx
+++ b/src/chapeau/chapeau.tsx
@@ -1,0 +1,12 @@
+import { Text } from '../text';
+import { chapeauStyle } from './styles';
+
+type ChapeauProps = {
+  children: React.ReactNode;
+} & React.HTMLAttributes<HTMLParagraphElement>;
+
+function Chapeau(props: ChapeauProps) {
+  return <Text as="p" css={chapeauStyle()} {...props} />;
+}
+
+export default Chapeau;

--- a/src/chapeau/index.ts
+++ b/src/chapeau/index.ts
@@ -1,0 +1,1 @@
+export { default as Chapeau } from './chapeau';

--- a/src/chapeau/styles.ts
+++ b/src/chapeau/styles.ts
@@ -1,0 +1,13 @@
+import { css } from '@emotion/react';
+
+import { tokens } from '../tokens';
+
+export function chapeauStyle() {
+  return css`
+    font-size: ${tokens.fontSizes.small};
+    font-weight: ${tokens.fontWeights.bold};
+    line-height: ${tokens.lineHeights.default};
+    letter-spacing: ${tokens.letterSpacing.relaxed};
+    text-transform: uppercase;
+  `;
+}

--- a/src/code-block/__tests__/__snapshots__/code-block.spec.tsx.snap
+++ b/src/code-block/__tests__/__snapshots__/code-block.spec.tsx.snap
@@ -1,0 +1,153 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Code renders snapshot of focused state 1`] = `
+.emotion-0 {
+  font-family: JetBrainsMonoNL,Menlo,Monaco,'Courier New',monospace;
+  font-weight: 400;
+  line-height: 1.5;
+  border-radius: 4px;
+  margin: 0 2px;
+  padding: 2px 4px;
+  white-space: nowrap;
+  font-size: 12px;
+  color: #05192D;
+  background-color: #EFEBE4;
+  padding: 8px;
+  margin: 0;
+  tab-size: 4;
+  white-space: pre;
+  overflow-x: auto;
+  outline: 0;
+  box-shadow: 0 0 0 2px #009BD8;
+}
+
+<pre
+  class="emotion-0"
+  data-testid="code-block-element"
+  tabindex="0"
+>
+  <code>
+    test
+  </code>
+</pre>
+`;
+
+exports[`Code renders snapshot of inverted size large 1`] = `
+.emotion-0 {
+  font-family: JetBrainsMonoNL,Menlo,Monaco,'Courier New',monospace;
+  font-weight: 400;
+  line-height: 1.5;
+  border-radius: 4px;
+  margin: 0 2px;
+  padding: 2px 4px;
+  white-space: nowrap;
+  font-size: 14px;
+  color: #FFFFFF;
+  background-color: rgba(255, 255, 255, 0.4);
+  padding: 8px;
+  margin: 0;
+  tab-size: 4;
+  white-space: pre;
+  overflow-x: auto;
+  outline: 0;
+}
+
+<pre
+  class="emotion-0"
+  tabindex="0"
+>
+  <code>
+    test
+  </code>
+</pre>
+`;
+
+exports[`Code renders snapshot of inverted size medium 1`] = `
+.emotion-0 {
+  font-family: JetBrainsMonoNL,Menlo,Monaco,'Courier New',monospace;
+  font-weight: 400;
+  line-height: 1.5;
+  border-radius: 4px;
+  margin: 0 2px;
+  padding: 2px 4px;
+  white-space: nowrap;
+  font-size: 12px;
+  color: #FFFFFF;
+  background-color: rgba(255, 255, 255, 0.4);
+  padding: 8px;
+  margin: 0;
+  tab-size: 4;
+  white-space: pre;
+  overflow-x: auto;
+  outline: 0;
+}
+
+<pre
+  class="emotion-0"
+  tabindex="0"
+>
+  <code>
+    test
+  </code>
+</pre>
+`;
+
+exports[`Code renders snapshot of size large 1`] = `
+.emotion-0 {
+  font-family: JetBrainsMonoNL,Menlo,Monaco,'Courier New',monospace;
+  font-weight: 400;
+  line-height: 1.5;
+  border-radius: 4px;
+  margin: 0 2px;
+  padding: 2px 4px;
+  white-space: nowrap;
+  font-size: 14px;
+  color: #05192D;
+  background-color: #EFEBE4;
+  padding: 8px;
+  margin: 0;
+  tab-size: 4;
+  white-space: pre;
+  overflow-x: auto;
+  outline: 0;
+}
+
+<pre
+  class="emotion-0"
+  tabindex="0"
+>
+  <code>
+    test
+  </code>
+</pre>
+`;
+
+exports[`Code renders snapshot of size medium 1`] = `
+.emotion-0 {
+  font-family: JetBrainsMonoNL,Menlo,Monaco,'Courier New',monospace;
+  font-weight: 400;
+  line-height: 1.5;
+  border-radius: 4px;
+  margin: 0 2px;
+  padding: 2px 4px;
+  white-space: nowrap;
+  font-size: 12px;
+  color: #05192D;
+  background-color: #EFEBE4;
+  padding: 8px;
+  margin: 0;
+  tab-size: 4;
+  white-space: pre;
+  overflow-x: auto;
+  outline: 0;
+}
+
+<pre
+  class="emotion-0"
+  tabindex="0"
+>
+  <code>
+    test
+  </code>
+</pre>
+`;

--- a/src/code-block/__tests__/code-block-basic.story.tsx
+++ b/src/code-block/__tests__/code-block-basic.story.tsx
@@ -1,0 +1,21 @@
+import { css } from '@emotion/react';
+
+import { tokens } from '../../tokens';
+import { CodeBlock } from '../index';
+
+const wrapperStyle = css`
+  padding: ${tokens.spacing.medium};
+`;
+
+function Story() {
+  return (
+    <div css={wrapperStyle}>
+      <CodeBlock>{`font-family: 22px;
+font-weight: 700;
+line-height: 1.575;
+border-radius: 0;`}</CodeBlock>
+    </div>
+  );
+}
+
+export default Story;

--- a/src/code-block/__tests__/code-block-sizes.story.tsx
+++ b/src/code-block/__tests__/code-block-sizes.story.tsx
@@ -1,0 +1,54 @@
+import { css } from '@emotion/react';
+
+import { tokens } from '../../tokens';
+import { CodeBlock } from '../index';
+
+const wrapperStyle = css`
+  display: flex;
+  flex-wrap: wrap;
+  gap: ${tokens.spacing.medium};
+  padding: ${tokens.spacing.medium};
+`;
+
+const sizes = ['medium', 'large'] as const;
+
+const preformattedCodeExample = `pyftsubset JetBrainsMono.ttf
+ --output-file="JetBrainsMono.woff"
+ --flavor=woff
+ --with-zopfli
+ --layout-features="kern,liga,clig,ccmp"
+ --unicodes="*"`;
+
+function Story() {
+  return (
+    <>
+      {/* Regular */}
+      <div css={wrapperStyle}>
+        {sizes.map((size) => {
+          return (
+            <CodeBlock key={size} size={size}>
+              {preformattedCodeExample}
+            </CodeBlock>
+          );
+        })}
+      </div>
+      {/* Inverted */}
+      <div
+        css={css`
+          ${wrapperStyle}
+          background-color: ${tokens.colors.navy};
+        `}
+      >
+        {sizes.map((size) => {
+          return (
+            <CodeBlock key={size} inverted size={size}>
+              {preformattedCodeExample}
+            </CodeBlock>
+          );
+        })}
+      </div>
+    </>
+  );
+}
+
+export default Story;

--- a/src/code-block/__tests__/code-block.e2e.ts
+++ b/src/code-block/__tests__/code-block.e2e.ts
@@ -1,25 +1,16 @@
 describe('CodeBlock', () => {
   it('render basic code block', () => {
     cy.loadStory('code-block-basic');
-    cy.injectAxe();
-
     cy.get('main').find('pre').should('have.length', 1);
-    cy.a11yCheck();
   });
 
   it('renders proper focus state', () => {
     cy.loadStory('code-block-basic');
-    cy.injectAxe();
-
     cy.get('main').find('pre').focus();
-    cy.a11yCheck();
   });
 
   it('render all sizes', () => {
     cy.loadStory('code-block-sizes');
-    cy.injectAxe();
-
     cy.get('main').find('pre').should('have.length', 4);
-    cy.a11yCheck();
   });
 });

--- a/src/code-block/__tests__/code-block.e2e.ts
+++ b/src/code-block/__tests__/code-block.e2e.ts
@@ -1,0 +1,25 @@
+describe('CodeBlock', () => {
+  it('render basic code block', () => {
+    cy.loadStory('code-block-basic');
+    cy.injectAxe();
+
+    cy.get('main').find('pre').should('have.length', 1);
+    cy.a11yCheck();
+  });
+
+  it('renders proper focus state', () => {
+    cy.loadStory('code-block-basic');
+    cy.injectAxe();
+
+    cy.get('main').find('pre').focus();
+    cy.a11yCheck();
+  });
+
+  it('render all sizes', () => {
+    cy.loadStory('code-block-sizes');
+    cy.injectAxe();
+
+    cy.get('main').find('pre').should('have.length', 4);
+    cy.a11yCheck();
+  });
+});

--- a/src/code-block/__tests__/code-block.spec.tsx
+++ b/src/code-block/__tests__/code-block.spec.tsx
@@ -1,0 +1,75 @@
+import { render, fireEvent } from '@testing-library/react';
+
+import { CodeBlock } from '../index';
+
+const sizes = ['medium', 'large'] as const;
+
+describe('Code', () => {
+  it('renders pre and code elements containing the text', () => {
+    const { container } = render(
+      <CodeBlock>{`pyftsubset JetBrainsMono.ttf
+ --output-file="JetBrainsMono.woff"
+ --flavor=woff
+ --with-zopfli
+ --layout-features="kern,liga,clig,ccmp"
+ --unicodes="*"`}</CodeBlock>,
+    );
+
+    const preElement = container.querySelector('pre');
+    const codeElement = container.querySelector('code');
+
+    expect(preElement).toBeInTheDocument();
+    expect(preElement).toContainElement(codeElement);
+    expect(codeElement).toBeInTheDocument();
+    expect(codeElement).toHaveTextContent(/JetBrainsMono.woff/i);
+  });
+
+  it('sets the data attribute on the pre element', () => {
+    const { getByTestId } = render(
+      <CodeBlock data-testid="code-block-element">
+        npm install @datacamp/waffles
+      </CodeBlock>,
+    );
+
+    const preElement = getByTestId('code-block-element');
+
+    expect(preElement).toBeInTheDocument();
+  });
+
+  it('renders snapshot of focused state', () => {
+    const { getByTestId } = render(
+      <CodeBlock data-testid="code-block-element">test</CodeBlock>,
+    );
+
+    const preElement = getByTestId('code-block-element');
+    fireEvent.focus(preElement);
+
+    expect(preElement).toMatchSnapshot();
+  });
+
+  describe('renders snapshot of', () => {
+    sizes.forEach((size) => {
+      it(`size ${size}`, () => {
+        const { container } = render(<CodeBlock size={size}>test</CodeBlock>);
+
+        const codeElement = container.querySelector('pre');
+        expect(codeElement).toMatchSnapshot();
+      });
+    });
+  });
+
+  describe('renders snapshot of inverted', () => {
+    sizes.forEach((size) => {
+      it(`size ${size}`, () => {
+        const { container } = render(
+          <CodeBlock size={size} inverted>
+            test
+          </CodeBlock>,
+        );
+
+        const codeElement = container.querySelector('pre');
+        expect(codeElement).toMatchSnapshot();
+      });
+    });
+  });
+});

--- a/src/code-block/code-block.tsx
+++ b/src/code-block/code-block.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import { Code } from '../code';
+import { codeBlockStyle } from './styles';
+
+type CodeBlockProps = React.ComponentProps<typeof Code>;
+
+function CodeBlock({ children, ...restProps }: CodeBlockProps) {
+  return (
+    <Code as="pre" css={codeBlockStyle()} {...restProps}>
+      <code>{children}</code>
+    </Code>
+  );
+}
+
+export default CodeBlock;

--- a/src/code-block/code-block.tsx
+++ b/src/code-block/code-block.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useFocusRing } from '@react-aria/focus';
 
 import { Code } from '../code';
 import { codeBlockStyle } from './styles';
@@ -6,8 +7,16 @@ import { codeBlockStyle } from './styles';
 type CodeBlockProps = React.ComponentProps<typeof Code>;
 
 function CodeBlock({ children, ...restProps }: CodeBlockProps) {
+  const { focusProps, isFocusVisible } = useFocusRing();
+
   return (
-    <Code as="pre" css={codeBlockStyle()} {...restProps}>
+    <Code
+      as="pre"
+      css={codeBlockStyle({ isFocusVisible })}
+      tabIndex={0}
+      {...restProps}
+      {...focusProps}
+    >
       <code>{children}</code>
     </Code>
   );

--- a/src/code-block/index.ts
+++ b/src/code-block/index.ts
@@ -1,0 +1,1 @@
+export { default as CodeBlock } from './code-block';

--- a/src/code-block/styles.ts
+++ b/src/code-block/styles.ts
@@ -2,12 +2,22 @@ import { css } from '@emotion/react';
 
 import { tokens } from '../tokens';
 
-export function codeBlockStyle() {
+type CodeBlockStyleOptions = {
+  isFocusVisible: boolean;
+};
+
+export function codeBlockStyle({ isFocusVisible }: CodeBlockStyleOptions) {
   return css`
     padding: ${tokens.spacing.small};
     margin: 0;
     tab-size: 4;
     white-space: pre;
     overflow-x: auto;
+    outline: 0;
+
+    ${isFocusVisible &&
+    css`
+      box-shadow: 0 0 0 2px ${tokens.colors.blueDark};
+    `};
   `;
 }

--- a/src/code-block/styles.ts
+++ b/src/code-block/styles.ts
@@ -1,0 +1,13 @@
+import { css } from '@emotion/react';
+
+import { tokens } from '../tokens';
+
+export function codeBlockStyle() {
+  return css`
+    padding: ${tokens.spacing.small};
+    margin: 0;
+    tab-size: 4;
+    white-space: pre;
+    overflow-x: auto;
+  `;
+}

--- a/src/code/__tests__/__snapshots__/code.spec.tsx.snap
+++ b/src/code/__tests__/__snapshots__/code.spec.tsx.snap
@@ -1,0 +1,85 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Code renders snapshot of inverted size large 1`] = `
+.emotion-0 {
+  font-family: JetBrainsMonoNL,Menlo,Monaco,'Courier New',monospace;
+  font-weight: 400;
+  line-height: 1.5;
+  border-radius: 4px;
+  margin: 0 2px;
+  padding: 2px 4px;
+  white-space: nowrap;
+  font-size: 14px;
+  color: #FFFFFF;
+  background-color: rgba(255, 255, 255, 0.4);
+}
+
+<code
+  class="emotion-0"
+>
+  test
+</code>
+`;
+
+exports[`Code renders snapshot of inverted size medium 1`] = `
+.emotion-0 {
+  font-family: JetBrainsMonoNL,Menlo,Monaco,'Courier New',monospace;
+  font-weight: 400;
+  line-height: 1.5;
+  border-radius: 4px;
+  margin: 0 2px;
+  padding: 2px 4px;
+  white-space: nowrap;
+  font-size: 12px;
+  color: #FFFFFF;
+  background-color: rgba(255, 255, 255, 0.4);
+}
+
+<code
+  class="emotion-0"
+>
+  test
+</code>
+`;
+
+exports[`Code renders snapshot of size large 1`] = `
+.emotion-0 {
+  font-family: JetBrainsMonoNL,Menlo,Monaco,'Courier New',monospace;
+  font-weight: 400;
+  line-height: 1.5;
+  border-radius: 4px;
+  margin: 0 2px;
+  padding: 2px 4px;
+  white-space: nowrap;
+  font-size: 14px;
+  color: #05192D;
+  background-color: #EFEBE4;
+}
+
+<code
+  class="emotion-0"
+>
+  test
+</code>
+`;
+
+exports[`Code renders snapshot of size medium 1`] = `
+.emotion-0 {
+  font-family: JetBrainsMonoNL,Menlo,Monaco,'Courier New',monospace;
+  font-weight: 400;
+  line-height: 1.5;
+  border-radius: 4px;
+  margin: 0 2px;
+  padding: 2px 4px;
+  white-space: nowrap;
+  font-size: 12px;
+  color: #05192D;
+  background-color: #EFEBE4;
+}
+
+<code
+  class="emotion-0"
+>
+  test
+</code>
+`;

--- a/src/code/__tests__/code-sizes.story.tsx
+++ b/src/code/__tests__/code-sizes.story.tsx
@@ -1,0 +1,58 @@
+import { css } from '@emotion/react';
+
+import { tokens } from '../../tokens';
+import { Paragraph } from '../../paragraph';
+import { Code } from '../index';
+
+const wrapperStyle = css`
+  padding: ${tokens.spacing.medium};
+`;
+
+const sizes = ['medium', 'large'] as const;
+
+function Story() {
+  return (
+    <>
+      {/* Regular */}
+      <div css={wrapperStyle}>
+        {sizes.map((size) => {
+          return (
+            <Paragraph key={size}>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+              eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut{' '}
+              <Code
+                size={size}
+              >{`inline code fragment of the ${size} size`}</Code>{' '}
+              enim ad minim veniam, quis nostrud exercitation ullamco laboris
+              nisi ut aliquip ex ea commodo consequat.
+            </Paragraph>
+          );
+        })}
+      </div>
+      {/* Inverted */}
+      <div
+        css={css`
+          ${wrapperStyle}
+          background-color: ${tokens.colors.navy};
+        `}
+      >
+        {sizes.map((size) => {
+          return (
+            <Paragraph inverted key={size}>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+              eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut{' '}
+              <Code
+                inverted
+                size={size}
+              >{`inline inverted style code fragment of the ${size} size`}</Code>{' '}
+              enim ad minim veniam, quis nostrud exercitation ullamco laboris
+              nisi ut aliquip ex ea commodo consequat.
+            </Paragraph>
+          );
+        })}
+      </div>
+    </>
+  );
+}
+
+export default Story;

--- a/src/code/__tests__/code.e2e.ts
+++ b/src/code/__tests__/code.e2e.ts
@@ -1,0 +1,9 @@
+describe('Code', () => {
+  it('render all sizes', () => {
+    cy.loadStory('code-sizes');
+    cy.injectAxe();
+
+    cy.get('main').find('code').should('have.length', 4);
+    cy.a11yCheck();
+  });
+});

--- a/src/code/__tests__/code.e2e.ts
+++ b/src/code/__tests__/code.e2e.ts
@@ -1,9 +1,6 @@
 describe('Code', () => {
   it('render all sizes', () => {
     cy.loadStory('code-sizes');
-    cy.injectAxe();
-
     cy.get('main').find('code').should('have.length', 4);
-    cy.a11yCheck();
   });
 });

--- a/src/code/__tests__/code.spec.tsx
+++ b/src/code/__tests__/code.spec.tsx
@@ -1,0 +1,61 @@
+import { render } from '@testing-library/react';
+
+import { Code } from '../index';
+
+const sizes = ['medium', 'large'] as const;
+
+describe('Code', () => {
+  it('renders a code element containing the text by default', () => {
+    const { container } = render(<Code>npm run test -- -u</Code>);
+
+    const codeElement = container.querySelector('code');
+
+    expect(codeElement).toBeInTheDocument();
+    expect(codeElement).toHaveTextContent('npm run test -- -u');
+  });
+
+  it('renders a pre element if it is passed via "as" prop', () => {
+    const { container } = render(<Code as="pre">npm run test</Code>);
+
+    const codeElement = container.querySelector('pre');
+
+    expect(codeElement).toBeInTheDocument();
+    expect(codeElement).toHaveTextContent('npm run test');
+  });
+
+  it('sets the data attribute on the code element', () => {
+    const { getByTestId } = render(
+      <Code data-testid="code-element">npm run test -- -u</Code>,
+    );
+
+    const codeElement = getByTestId('code-element');
+
+    expect(codeElement).toBeInTheDocument();
+  });
+
+  describe('renders snapshot of', () => {
+    sizes.forEach((size) => {
+      it(`size ${size}`, () => {
+        const { container } = render(<Code size={size}>test</Code>);
+
+        const codeElement = container.querySelector('code');
+        expect(codeElement).toMatchSnapshot();
+      });
+    });
+  });
+
+  describe('renders snapshot of inverted', () => {
+    sizes.forEach((size) => {
+      it(`size ${size}`, () => {
+        const { container } = render(
+          <Code size={size} inverted>
+            test
+          </Code>,
+        );
+
+        const codeElement = container.querySelector('code');
+        expect(codeElement).toMatchSnapshot();
+      });
+    });
+  });
+});

--- a/src/code/code.tsx
+++ b/src/code/code.tsx
@@ -1,0 +1,13 @@
+import { codeStyle } from './styles';
+
+type CodeProps = {
+  children: React.ReactNode;
+  size?: 'medium' | 'large';
+  inverted?: boolean;
+} & React.HTMLAttributes<HTMLElement>;
+
+function Code({ size = 'medium', inverted = false, ...restProps }: CodeProps) {
+  return <code css={codeStyle({ size, inverted })} {...restProps} />;
+}
+
+export default Code;

--- a/src/code/code.tsx
+++ b/src/code/code.tsx
@@ -1,13 +1,21 @@
 import { codeStyle } from './styles';
 
 type CodeProps = {
+  as?: 'code' | 'pre';
   children: React.ReactNode;
   size?: 'medium' | 'large';
   inverted?: boolean;
 } & React.HTMLAttributes<HTMLElement>;
 
-function Code({ size = 'medium', inverted = false, ...restProps }: CodeProps) {
-  return <code css={codeStyle({ size, inverted })} {...restProps} />;
+function Code({
+  as,
+  size = 'medium',
+  inverted = false,
+  ...restProps
+}: CodeProps) {
+  const Element = as || 'code';
+
+  return <Element css={codeStyle({ size, inverted })} {...restProps} />;
 }
 
 export default Code;

--- a/src/code/index.ts
+++ b/src/code/index.ts
@@ -1,0 +1,1 @@
+export { default as Code } from './code';

--- a/src/code/styles.ts
+++ b/src/code/styles.ts
@@ -1,0 +1,40 @@
+import { css } from '@emotion/react';
+
+import { tokens } from '../tokens';
+import { hexToRgba } from '../utils';
+import Code from './code';
+
+const sizeMap = {
+  medium: {
+    fontSize: tokens.fontSizes.small,
+  },
+  large: {
+    fontSize: tokens.fontSizes.medium,
+  },
+};
+
+const baseCodeStyle = css`
+  font-family: ${tokens.fontFamilies.mono};
+  font-weight: ${tokens.fontWeights.regular};
+  line-height: ${tokens.lineHeights.relaxed};
+  border-radius: ${tokens.borderRadius.medium};
+  margin: 0 2px;
+  padding: 2px 4px;
+  white-space: nowrap;
+`;
+
+type CodeStyleOptions = {
+  size: NonNullable<React.ComponentProps<typeof Code>['size']>;
+  inverted: boolean;
+};
+
+export function codeStyle({ size, inverted }: CodeStyleOptions) {
+  return css`
+    ${baseCodeStyle}
+    font-size: ${sizeMap[size].fontSize};
+    color: ${inverted ? tokens.colors.white : tokens.colors.navy};
+    background-color: ${inverted
+      ? hexToRgba(tokens.colors.white, tokens.opacity.medium)
+      : tokens.colors.beige};
+  `;
+}

--- a/src/content-container/__tests__/content-container.e2e.ts
+++ b/src/content-container/__tests__/content-container.e2e.ts
@@ -12,10 +12,7 @@ describe('ContentContainer', () => {
       it(`renders correctly on ${size} screen device`, () => {
         cy.viewport(width, height);
         cy.loadStory('content-container-no-sidebar');
-        cy.injectAxe();
-
         cy.findAllByTestId('container').should('have.length', 1);
-        cy.a11yCheck();
       });
     });
   });
@@ -27,10 +24,7 @@ describe('ContentContainer', () => {
       it(`renders correctly on ${size} screen device`, () => {
         cy.viewport(width, height);
         cy.loadStory('content-container-short-content');
-        cy.injectAxe();
-
         cy.findAllByTestId('container').should('have.length', 1);
-        cy.a11yCheck();
       });
     });
   });
@@ -45,10 +39,7 @@ describe('ContentContainer', () => {
       it(`renders correctly on ${size} screen device`, () => {
         cy.viewport(width, height);
         cy.loadStory('content-container-with-sidebar');
-        cy.injectAxe();
-
         cy.findAllByTestId('container').should('have.length', 1);
-        cy.a11yCheck();
       });
     });
   });

--- a/src/content-container/content-container.tsx
+++ b/src/content-container/content-container.tsx
@@ -5,7 +5,7 @@ import { contentContainerStyle } from './styles';
 type ContentContainerProps = {
   children: React.ReactNode;
   noSidebar?: boolean;
-} & React.ComponentPropsWithoutRef<'div'>;
+} & React.HTMLAttributes<HTMLDivElement>;
 
 function ContentContainer({
   children,

--- a/src/display/__tests__/__snapshots__/display.spec.tsx.snap
+++ b/src/display/__tests__/__snapshots__/display.spec.tsx.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Display renders snapshot 1`] = `
+.emotion-0 {
+  color: #05192D;
+  font-family: Studio-Feixen-Sans,Arial,sans-serif;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 1;
+  margin: 0;
+  padding: 0;
+  font-size: 28px;
+  font-weight: 800;
+  line-height: 1.25;
+  letter-spacing: -0.5px;
+}
+
+<p
+  class="emotion-0"
+>
+  Test
+</p>
+`;

--- a/src/display/__tests__/display-basic.story.tsx
+++ b/src/display/__tests__/display-basic.story.tsx
@@ -1,0 +1,18 @@
+import { css } from '@emotion/react';
+
+import { tokens } from '../../tokens';
+import { Display } from '../index';
+
+const wrapperStyle = css`
+  padding: ${tokens.spacing.medium};
+`;
+
+function Story() {
+  return (
+    <div css={wrapperStyle}>
+      <Display>Big and short non-semantic message</Display>
+    </div>
+  );
+}
+
+export default Story;

--- a/src/display/__tests__/display-styled.story.tsx
+++ b/src/display/__tests__/display-styled.story.tsx
@@ -1,0 +1,23 @@
+import { css } from '@emotion/react';
+
+import { tokens } from '../../tokens';
+import { Display } from '../index';
+
+const wrapperStyle = css`
+  padding: ${tokens.spacing.medium};
+`;
+
+const customDisplayStyle = css`
+  color: ${tokens.colors.purpleDarkText};
+  letter-spacing: ${tokens.letterSpacing.relaxed};
+`;
+
+function Story() {
+  return (
+    <div css={wrapperStyle}>
+      <Display css={customDisplayStyle}>Display with custom styles</Display>
+    </div>
+  );
+}
+
+export default Story;

--- a/src/display/__tests__/display.e2e.ts
+++ b/src/display/__tests__/display.e2e.ts
@@ -3,7 +3,7 @@ describe('Display', () => {
     cy.loadStory('display-basic');
     cy.injectAxe();
 
-    cy.findByText('Big and short non-semantic message');
+    cy.findByText('Big and short non-semantic message').should('exist');
     cy.a11yCheck();
   });
 

--- a/src/display/__tests__/display.e2e.ts
+++ b/src/display/__tests__/display.e2e.ts
@@ -1,0 +1,17 @@
+describe('Display', () => {
+  it('renders a basic text', () => {
+    cy.loadStory('display-basic');
+    cy.injectAxe();
+
+    cy.findByText('Big and short non-semantic message');
+    cy.a11yCheck();
+  });
+
+  it('renders with custom styles applied', () => {
+    cy.loadStory('display-styled');
+    cy.injectAxe();
+
+    cy.get('main').find('p').should('have.length', 1);
+    cy.a11yCheck();
+  });
+});

--- a/src/display/__tests__/display.e2e.ts
+++ b/src/display/__tests__/display.e2e.ts
@@ -1,17 +1,11 @@
 describe('Display', () => {
   it('renders a basic text', () => {
     cy.loadStory('display-basic');
-    cy.injectAxe();
-
     cy.findByText('Big and short non-semantic message').should('exist');
-    cy.a11yCheck();
   });
 
   it('renders with custom styles applied', () => {
     cy.loadStory('display-styled');
-    cy.injectAxe();
-
     cy.get('main').find('p').should('have.length', 1);
-    cy.a11yCheck();
   });
 });

--- a/src/display/__tests__/display.spec.tsx
+++ b/src/display/__tests__/display.spec.tsx
@@ -1,0 +1,23 @@
+import { render } from '@testing-library/react';
+
+import { Display } from '../index';
+
+describe('Display', () => {
+  it('renders a paragraph containing the text', () => {
+    const { container } = render(<Display>We are bold!</Display>);
+
+    const displayParagraph = container.querySelector('p');
+
+    expect(displayParagraph).toBeInTheDocument();
+    expect(displayParagraph).toHaveTextContent('We are bold!');
+  });
+
+  it('renders snapshot', () => {
+    const { getByText } = render(<Display>Test</Display>);
+
+    const displayParagraph = getByText('Test');
+
+    expect(displayParagraph).toBeInTheDocument();
+    expect(displayParagraph).toMatchSnapshot();
+  });
+});

--- a/src/display/display.tsx
+++ b/src/display/display.tsx
@@ -1,0 +1,12 @@
+import { Text } from '../text';
+import { displayStyle } from './styles';
+
+type DisplayProps = {
+  children: React.ReactNode;
+} & React.HTMLAttributes<HTMLParagraphElement>;
+
+function Display(props: DisplayProps) {
+  return <Text as="p" css={displayStyle()} {...props} />;
+}
+
+export default Display;

--- a/src/display/index.ts
+++ b/src/display/index.ts
@@ -1,0 +1,1 @@
+export { default as Display } from './display';

--- a/src/display/styles.ts
+++ b/src/display/styles.ts
@@ -1,0 +1,11 @@
+import { css } from '@emotion/react';
+
+import { tokens } from '../tokens';
+
+export function displayStyle() {
+  return css`
+    font-size: ${tokens.fontSizes.huge};
+    line-height: ${tokens.lineHeights.default};
+    letter-spacing: ${tokens.letterSpacing.tight};
+  `;
+}

--- a/src/display/styles.ts
+++ b/src/display/styles.ts
@@ -5,6 +5,7 @@ import { tokens } from '../tokens';
 export function displayStyle() {
   return css`
     font-size: ${tokens.fontSizes.huge};
+    font-weight: ${tokens.fontWeights.bold};
     line-height: ${tokens.lineHeights.default};
     letter-spacing: ${tokens.letterSpacing.tight};
   `;

--- a/src/heading/__tests__/__snapshots__/heading.spec.tsx.snap
+++ b/src/heading/__tests__/__snapshots__/heading.spec.tsx.snap
@@ -1,0 +1,89 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Heading renders snapshot of size large 1`] = `
+.emotion-0 {
+  color: #05192D;
+  font-family: Studio-Feixen-Sans,Arial,sans-serif;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 1;
+  margin: 0;
+  padding: 0;
+  font-weight: 800;
+  font-size: 16px;
+  margin-bottom: 8px;
+  line-height: 1.25;
+}
+
+<h3
+  class="emotion-0"
+>
+  Test
+</h3>
+`;
+
+exports[`Heading renders snapshot of size medium 1`] = `
+.emotion-0 {
+  color: #05192D;
+  font-family: Studio-Feixen-Sans,Arial,sans-serif;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 1;
+  margin: 0;
+  padding: 0;
+  font-weight: 800;
+  font-size: 14px;
+  margin-bottom: 8px;
+  line-height: 1.25;
+}
+
+<h4
+  class="emotion-0"
+>
+  Test
+</h4>
+`;
+
+exports[`Heading renders snapshot of size xlarge 1`] = `
+.emotion-0 {
+  color: #05192D;
+  font-family: Studio-Feixen-Sans,Arial,sans-serif;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 1;
+  margin: 0;
+  padding: 0;
+  font-weight: 800;
+  font-size: 18px;
+  margin-bottom: 8px;
+  line-height: 1.25;
+}
+
+<h2
+  class="emotion-0"
+>
+  Test
+</h2>
+`;
+
+exports[`Heading renders snapshot of size xxlarge 1`] = `
+.emotion-0 {
+  color: #05192D;
+  font-family: Studio-Feixen-Sans,Arial,sans-serif;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 1;
+  margin: 0;
+  padding: 0;
+  font-weight: 800;
+  font-size: 20px;
+  margin-bottom: 8px;
+  line-height: 1.25;
+}
+
+<h1
+  class="emotion-0"
+>
+  Test
+</h1>
+`;

--- a/src/heading/__tests__/heading-sizes.story.tsx
+++ b/src/heading/__tests__/heading-sizes.story.tsx
@@ -1,0 +1,24 @@
+import { css } from '@emotion/react';
+
+import { tokens } from '../../tokens';
+import { Heading } from '../index';
+
+const wrapperStyle = css`
+  padding: ${tokens.spacing.medium};
+`;
+
+const sizes = ['xxlarge', 'xlarge', 'large', 'medium'] as const;
+
+function Story() {
+  return (
+    <div css={wrapperStyle}>
+      {sizes.map((size) => {
+        return (
+          <Heading key={size} size={size}>{`Heading size ${size}`}</Heading>
+        );
+      })}
+    </div>
+  );
+}
+
+export default Story;

--- a/src/heading/__tests__/heading-styled.story.tsx
+++ b/src/heading/__tests__/heading-styled.story.tsx
@@ -1,0 +1,25 @@
+import { css } from '@emotion/react';
+
+import { tokens } from '../../tokens';
+import { Heading } from '../index';
+
+const wrapperStyle = css`
+  padding: ${tokens.spacing.medium};
+`;
+
+const customParagraphStyle = css`
+  color: ${tokens.colors.purpleDarkText};
+  font-size: ${tokens.fontSizes.huge};
+`;
+
+function Story() {
+  return (
+    <div css={wrapperStyle}>
+      <Heading css={customParagraphStyle}>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit
+      </Heading>
+    </div>
+  );
+}
+
+export default Story;

--- a/src/heading/__tests__/heading.e2e.ts
+++ b/src/heading/__tests__/heading.e2e.ts
@@ -1,20 +1,14 @@
 describe('Heading', () => {
   it('render all sizes', () => {
     cy.loadStory('heading-sizes');
-    cy.injectAxe();
-
     cy.get('main').find('h1').should('have.length', 1);
     cy.get('main').find('h2').should('have.length', 1);
     cy.get('main').find('h3').should('have.length', 1);
     cy.get('main').find('h4').should('have.length', 1);
-    cy.a11yCheck();
   });
 
   it('renders with custom styles applied', () => {
     cy.loadStory('heading-styled');
-    cy.injectAxe();
-
     cy.get('main').find('h2').should('have.length', 1);
-    cy.a11yCheck();
   });
 });

--- a/src/heading/__tests__/heading.e2e.ts
+++ b/src/heading/__tests__/heading.e2e.ts
@@ -1,0 +1,20 @@
+describe('Heading', () => {
+  it('render all sizes', () => {
+    cy.loadStory('heading-sizes');
+    cy.injectAxe();
+
+    cy.get('main').find('h1').should('have.length', 1);
+    cy.get('main').find('h2').should('have.length', 1);
+    cy.get('main').find('h3').should('have.length', 1);
+    cy.get('main').find('h4').should('have.length', 1);
+    cy.a11yCheck();
+  });
+
+  it('renders with custom styles applied', () => {
+    cy.loadStory('heading-styled');
+    cy.injectAxe();
+
+    cy.get('main').find('h2').should('have.length', 1);
+    cy.a11yCheck();
+  });
+});

--- a/src/heading/__tests__/heading.spec.tsx
+++ b/src/heading/__tests__/heading.spec.tsx
@@ -1,0 +1,62 @@
+import { render } from '@testing-library/react';
+
+import { Heading } from '../index';
+
+const sizes = ['xxlarge', 'xlarge', 'large', 'medium'] as const;
+
+describe('Heading', () => {
+  it('renders a h2 element by default containing the text', () => {
+    const { container } = render(
+      <Heading>Remarkable Taylor Swift live performance</Heading>,
+    );
+
+    const heading = container.querySelector('h2');
+
+    expect(heading).toBeInTheDocument();
+    expect(heading).toHaveTextContent(
+      'Remarkable Taylor Swift live performance',
+    );
+  });
+
+  it('sets the data attribute on the heading', () => {
+    const { getByTestId } = render(
+      <Heading data-testid="custom-heading">
+        Remarkable Taylor Swift live performance
+      </Heading>,
+    );
+
+    const heading = getByTestId('custom-heading');
+
+    expect(heading).toBeInTheDocument();
+  });
+
+  it('default heading level associated with size could be overwrited', () => {
+    const { container } = render(
+      <Heading size="xxlarge" as="h6">
+        Remarkable Taylor Swift live performance
+      </Heading>,
+    );
+
+    const heading = container.querySelector('h6');
+
+    expect(heading).toBeInTheDocument();
+    expect(heading).toHaveTextContent(
+      'Remarkable Taylor Swift live performance',
+    );
+  });
+
+  describe('renders snapshot of', () => {
+    sizes.forEach((size) => {
+      it(`size ${size}`, () => {
+        const { getByText } = render(
+          <Heading key={size} size={size}>
+            Test
+          </Heading>,
+        );
+
+        const heading = getByText('Test');
+        expect(heading).toMatchSnapshot();
+      });
+    });
+  });
+});

--- a/src/heading/heading.tsx
+++ b/src/heading/heading.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+import { Text } from '../text';
+import { headingStyle, sizeToElement } from './styles';
+
+type HeadingProps = {
+  children: React.ReactNode;
+  as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+  size?: 'xxlarge' | 'xlarge' | 'large' | 'medium';
+} & React.HTMLAttributes<HTMLHeadingElement>;
+
+function Heading({ as, size = 'xlarge', ...restProps }: HeadingProps) {
+  return (
+    <Text
+      as={as ? as : sizeToElement({ size })}
+      css={headingStyle({ size })}
+      {...restProps}
+    />
+  );
+}
+
+export default Heading;

--- a/src/heading/index.ts
+++ b/src/heading/index.ts
@@ -1,0 +1,1 @@
+export { default as Heading } from './heading';

--- a/src/heading/styles.ts
+++ b/src/heading/styles.ts
@@ -35,6 +35,7 @@ export function headingStyle({ size }: SizeOptions) {
     font-weight: ${tokens.fontWeights.bold};
     font-size: ${sizeMap[size].fontSize};
     margin-bottom: ${tokens.spacing.small};
+    line-height: ${tokens.lineHeights.default};
   `;
 }
 

--- a/src/heading/styles.ts
+++ b/src/heading/styles.ts
@@ -1,0 +1,43 @@
+import { css } from '@emotion/react';
+
+import { tokens } from '../tokens';
+import Heading from './heading';
+
+// Mapping between heading size, HTML elements, and actual font size
+
+const sizeMap = {
+  xxlarge: {
+    fontSize: tokens.fontSizes.xxlarge,
+    element: 'h1',
+  },
+  xlarge: {
+    element: 'h2',
+    fontSize: tokens.fontSizes.xlarge,
+  },
+  large: {
+    element: 'h3',
+    fontSize: tokens.fontSizes.large,
+  },
+  medium: {
+    element: 'h4',
+    fontSize: tokens.fontSizes.medium,
+  },
+} as const;
+
+// Generate heading style and default HTML element (from h1 to h4) based on provided size
+
+type SizeOptions = {
+  size: NonNullable<React.ComponentProps<typeof Heading>['size']>;
+};
+
+export function headingStyle({ size }: SizeOptions) {
+  return css`
+    font-weight: ${tokens.fontWeights.bold};
+    font-size: ${sizeMap[size].fontSize};
+    margin-bottom: ${tokens.spacing.small};
+  `;
+}
+
+export function sizeToElement({ size }: SizeOptions) {
+  return sizeMap[size].element;
+}

--- a/src/icon/__tests__/icon.e2e.ts
+++ b/src/icon/__tests__/icon.e2e.ts
@@ -1,9 +1,6 @@
 describe('Icon', () => {
   it('render all availbable icons in different sizes', () => {
     cy.loadStory('icon-sizes');
-    cy.injectAxe();
-
     cy.findAllByTestId('icon-row').should('have.length', 190);
-    cy.a11yCheck();
   });
 });

--- a/src/link/__tests__/__snapshots__/link.spec.tsx.snap
+++ b/src/link/__tests__/__snapshots__/link.spec.tsx.snap
@@ -1,0 +1,98 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[` 1`] = `
+.emotion-0 {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-family: Studio-Feixen-Sans,Arial,sans-serif;
+  font-weight: 800;
+  font-size: 14px;
+  line-height: 1.5;
+  outline: 0;
+  border-radius: 4px;
+  -webkit-transition: box-shadow 125ms ease-out;
+  transition: box-shadow 125ms ease-out;
+  color: #0075AD;
+}
+
+.emotion-0:hover:not(:focus) {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+<a
+  class="emotion-0"
+  href="https://taylor-swift-fanclub.com"
+>
+  <span
+    class="emotion-1"
+  >
+    Join Taylor Swift Fanclub
+  </span>
+</a>
+`;
+
+exports[` 2`] = `
+.emotion-0 {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-family: Studio-Feixen-Sans,Arial,sans-serif;
+  font-weight: 800;
+  font-size: 14px;
+  line-height: 1.5;
+  outline: 0;
+  border-radius: 4px;
+  -webkit-transition: box-shadow 125ms ease-out;
+  transition: box-shadow 125ms ease-out;
+  color: #009BD8;
+}
+
+.emotion-0:hover:not(:focus) {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+<a
+  class="emotion-0"
+  href="https://taylor-swift-fanclub.com"
+>
+  <span
+    class="emotion-1"
+  >
+    Join Taylor Swift Fanclub
+  </span>
+</a>
+`;
+
+exports[`Link renders snapshot of focused state 1`] = `
+.emotion-0 {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-family: Studio-Feixen-Sans,Arial,sans-serif;
+  font-weight: 800;
+  font-size: 14px;
+  line-height: 1.5;
+  outline: 0;
+  border-radius: 4px;
+  -webkit-transition: box-shadow 125ms ease-out;
+  transition: box-shadow 125ms ease-out;
+  color: #0075AD;
+  box-shadow: 0 0 0 2px #009BD8;
+}
+
+.emotion-0:hover:not(:focus) {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+<a
+  class="emotion-0"
+  href="https://datacamp.com"
+>
+  <span
+    class="emotion-1"
+  >
+    Test
+  </span>
+</a>
+`;

--- a/src/link/__tests__/link-basic.story.tsx
+++ b/src/link/__tests__/link-basic.story.tsx
@@ -1,0 +1,24 @@
+import { css } from '@emotion/react';
+
+import { tokens } from '../../tokens';
+import { Paragraph } from '../../paragraph';
+import { Link } from '../index';
+
+const wrapperStyle = css`
+  padding: ${tokens.spacing.medium};
+`;
+
+function Story() {
+  return (
+    <div css={wrapperStyle}>
+      <Paragraph>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, <Link href="https://datacamp.com">Go to DataCamp website</Link>{' '}
+        ullamco laboris nisi ut aliquip ex ea commodo consequat.
+      </Paragraph>
+    </div>
+  );
+}
+
+export default Story;

--- a/src/link/__tests__/link-inverted.story.tsx
+++ b/src/link/__tests__/link-inverted.story.tsx
@@ -1,0 +1,28 @@
+import { css } from '@emotion/react';
+
+import { tokens } from '../../tokens';
+import { Paragraph } from '../../paragraph';
+import { Link } from '../index';
+
+const wrapperStyle = css`
+  padding: ${tokens.spacing.medium};
+  background-color: ${tokens.colors.navy};
+`;
+
+function Story() {
+  return (
+    <div css={wrapperStyle}>
+      <Paragraph inverted>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam,{' '}
+        <Link inverted href="https://datacamp.com">
+          Go to DataCamp website
+        </Link>{' '}
+        ullamco laboris nisi ut aliquip ex ea commodo consequat.
+      </Paragraph>
+    </div>
+  );
+}
+
+export default Story;

--- a/src/link/__tests__/link-styled.story.tsx
+++ b/src/link/__tests__/link-styled.story.tsx
@@ -1,0 +1,32 @@
+import { css } from '@emotion/react';
+
+import { tokens } from '../../tokens';
+import { Paragraph } from '../../paragraph';
+import { Link } from '../index';
+
+const wrapperStyle = css`
+  padding: ${tokens.spacing.medium};
+`;
+
+const customLinkStyle = css`
+  color: ${tokens.colors.navy};
+  background-color: ${tokens.colors.greenLight};
+`;
+
+function Story() {
+  return (
+    <div css={wrapperStyle}>
+      <Paragraph>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam,{' '}
+        <Link css={customLinkStyle} href="https://datacamp.com">
+          Go to DataCamp website
+        </Link>{' '}
+        ullamco laboris nisi ut aliquip ex ea commodo consequat.
+      </Paragraph>
+    </div>
+  );
+}
+
+export default Story;

--- a/src/link/__tests__/link-with-icons.story.tsx
+++ b/src/link/__tests__/link-with-icons.story.tsx
@@ -1,0 +1,104 @@
+import { css } from '@emotion/react';
+
+import { tokens } from '../../tokens';
+import { AddCircle, ExternalLink } from '../../icon';
+import { Paragraph } from '../../paragraph';
+import { Link } from '../index';
+
+const wrapperStyle = css`
+  padding: ${tokens.spacing.medium};
+`;
+
+const iconSizes = ['xsmall', 'small', 'medium'] as const;
+
+function Story() {
+  return (
+    <>
+      {/* Regular */}
+      <div css={wrapperStyle}>
+        <Paragraph>
+          Ut enim ad minim veniam,{' '}
+          <Link iconLeft={<AddCircle />} href="https://datacamp.com">
+            Go to DataCamp website
+          </Link>{' '}
+          ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        </Paragraph>
+        <Paragraph>
+          Ut enim ad minim veniam,{' '}
+          <Link iconRight={<ExternalLink />} href="https://datacamp.com">
+            Go to DataCamp website
+          </Link>{' '}
+          ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        </Paragraph>
+        <Paragraph>
+          Ut enim ad minim veniam,{' '}
+          <Link
+            iconLeft={<AddCircle />}
+            iconRight={<ExternalLink />}
+            href="https://datacamp.com"
+          >
+            Go to DataCamp website
+          </Link>{' '}
+          ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        </Paragraph>
+      </div>
+      {/* Inverted */}
+      <div
+        css={css`
+          ${wrapperStyle}
+          background-color: ${tokens.colors.navy};
+        `}
+      >
+        <Paragraph inverted>
+          Ut enim ad minim veniam,{' '}
+          <Link inverted iconLeft={<AddCircle />} href="https://datacamp.com">
+            Go to DataCamp website
+          </Link>{' '}
+          ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        </Paragraph>
+        <Paragraph inverted>
+          Ut enim ad minim veniam,{' '}
+          <Link
+            inverted
+            iconRight={<ExternalLink />}
+            href="https://datacamp.com"
+          >
+            Go to DataCamp website
+          </Link>{' '}
+          ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        </Paragraph>
+        <Paragraph inverted>
+          Ut enim ad minim veniam,{' '}
+          <Link
+            inverted
+            iconLeft={<AddCircle />}
+            iconRight={<ExternalLink />}
+            href="https://datacamp.com"
+          >
+            Go to DataCamp website
+          </Link>{' '}
+          ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        </Paragraph>
+      </div>
+      {/* Custom icon size */}
+      <div css={wrapperStyle}>
+        {iconSizes.map((iconSize) => {
+          return (
+            <Paragraph key={`icon-size-${iconSize}`}>
+              Ut enim ad minim veniam,{' '}
+              <Link
+                iconLeft={<AddCircle size={iconSize} />}
+                href="https://datacamp.com"
+              >
+                Go to DataCamp website
+              </Link>{' '}
+              ullamco laboris nisi ut aliquip ex ea commodo consequat.
+            </Paragraph>
+          );
+        })}
+      </div>
+    </>
+  );
+}
+
+export default Story;

--- a/src/link/__tests__/link.e2e.ts
+++ b/src/link/__tests__/link.e2e.ts
@@ -1,41 +1,26 @@
 describe('Link', () => {
   it('renders a basic link', () => {
     cy.loadStory('link-basic');
-    cy.injectAxe();
-
     cy.get('a').should('have.length', 1);
-    cy.a11yCheck();
   });
 
   it('renders inverted link', () => {
     cy.loadStory('link-inverted');
-    cy.injectAxe();
-
     cy.get('a').should('have.length', 1);
-    cy.a11yCheck();
   });
 
   it('renders proper focus state', () => {
     cy.loadStory('link-basic');
-    cy.injectAxe();
-
     cy.get('a').focus();
-    cy.a11yCheck();
   });
 
   it('renders with custom styles applied', () => {
     cy.loadStory('link-styled');
-    cy.injectAxe();
-
     cy.findByText('Go to DataCamp website').should('exist');
-    cy.a11yCheck();
   });
 
   it('render regular and inverted with various icons', () => {
     cy.loadStory('link-with-icons');
-    cy.injectAxe();
-
     cy.get('a').should('have.length', 9);
-    cy.a11yCheck();
   });
 });

--- a/src/link/__tests__/link.e2e.ts
+++ b/src/link/__tests__/link.e2e.ts
@@ -1,0 +1,33 @@
+describe('Link', () => {
+  it('renders a basic link', () => {
+    cy.loadStory('link-basic');
+    cy.injectAxe();
+
+    cy.get('a').should('have.length', 1);
+    cy.a11yCheck();
+  });
+
+  it('renders inverted link', () => {
+    cy.loadStory('link-inverted');
+    cy.injectAxe();
+
+    cy.get('a').should('have.length', 1);
+    cy.a11yCheck();
+  });
+
+  it('renders proper focus state', () => {
+    cy.loadStory('link-basic');
+    cy.injectAxe();
+
+    cy.get('a').focus();
+    cy.a11yCheck();
+  });
+
+  it('renders with custom styles applied', () => {
+    cy.loadStory('link-styled');
+    cy.injectAxe();
+
+    cy.findByText('Go to DataCamp website').should('exist');
+    cy.a11yCheck();
+  });
+});

--- a/src/link/__tests__/link.e2e.ts
+++ b/src/link/__tests__/link.e2e.ts
@@ -30,4 +30,12 @@ describe('Link', () => {
     cy.findByText('Go to DataCamp website').should('exist');
     cy.a11yCheck();
   });
+
+  it('render regular and inverted with various icons', () => {
+    cy.loadStory('link-with-icons');
+    cy.injectAxe();
+
+    cy.get('a').should('have.length', 9);
+    cy.a11yCheck();
+  });
 });

--- a/src/link/__tests__/link.spec.tsx
+++ b/src/link/__tests__/link.spec.tsx
@@ -1,0 +1,166 @@
+import React, { useRef, useEffect } from 'react';
+import { render, fireEvent } from '@testing-library/react';
+
+import { AddCircle, ExternalLink } from '../../icon';
+import { Link } from '../index';
+
+type TestComponentProps = {
+  to: string;
+} & React.ComponentPropsWithoutRef<'a'>;
+
+function TestComponent({ children, to, ...restProps }: TestComponentProps) {
+  return (
+    <a href={to} {...restProps}>
+      {children}
+    </a>
+  );
+}
+
+function TestRefLink() {
+  const linkRef = useRef<HTMLAnchorElement>(null);
+
+  useEffect(() => {
+    linkRef.current?.focus();
+  }, []);
+
+  return (
+    <Link href="https://datacamp.com" ref={linkRef}>
+      Focused With Ref
+    </Link>
+  );
+}
+
+describe('Link', () => {
+  it('renders a link containing the text', () => {
+    const { container } = render(
+      <Link href="https://taylor-swift-fanclub.com">
+        Join Taylor Swift Fanclub
+      </Link>,
+    );
+
+    const link = container.querySelector('a');
+
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', 'https://taylor-swift-fanclub.com');
+    expect(link).toHaveTextContent('Join Taylor Swift Fanclub');
+  });
+
+  it('sets the data attribute on the link', () => {
+    const { getByTestId } = render(
+      <Link data-testid="taylors-link">Join Taylor Swift Fanclub</Link>,
+    );
+
+    const link = getByTestId('taylors-link');
+
+    expect(link).toBeInTheDocument();
+  });
+
+  it('renders left icon', () => {
+    const { container, getByText } = render(
+      <Link iconLeft={<AddCircle />}>Go to Fanpage</Link>,
+    );
+
+    const link = getByText('Go to Fanpage').closest('a');
+    const icon = container.querySelector('svg');
+
+    expect(link).toBeInTheDocument();
+    expect(link).toContainElement(icon);
+  });
+
+  it('renders right icon', () => {
+    const { container, getByText } = render(
+      <Link iconRight={<ExternalLink />}>Read More</Link>,
+    );
+
+    const link = getByText('Read More').closest('a');
+    const icon = container.querySelector('svg');
+
+    expect(link).toBeInTheDocument();
+    expect(link).toContainElement(icon);
+  });
+
+  it('renders both left and right icons', () => {
+    const { container, getByText } = render(
+      <Link iconLeft={<AddCircle />} iconRight={<ExternalLink />}>
+        Go to Another Fanpage
+      </Link>,
+    );
+
+    const link = getByText('Go to Another Fanpage');
+    const icons = container.querySelectorAll('svg');
+
+    expect(link).toBeInTheDocument();
+    expect(icons).toHaveLength(2);
+  });
+
+  it('renders icon of custom size', () => {
+    const { container, getByText } = render(
+      <Link iconRight={<ExternalLink size="xsmall" />}>
+        Go to Another Fanpage
+      </Link>,
+    );
+
+    const link = getByText('Go to Another Fanpage').closest('a');
+    const icon = container.querySelector('svg');
+
+    expect(link).toBeInTheDocument();
+    expect(link).toContainElement(icon);
+    expect(icon).toHaveAttribute('width', '12');
+    expect(icon).toHaveAttribute('height', '12');
+  });
+
+  it('requires props owned by custom component passed into "as" prop', () => {
+    const { container } = render(
+      <Link to="http://fanpage.com" as={TestComponent}>
+        As a Custom Component
+      </Link>,
+    );
+
+    const customComponent = container.querySelector('a');
+
+    expect(customComponent).toBeInTheDocument();
+    expect(customComponent).toHaveTextContent('As a Custom Component');
+    expect(customComponent).toHaveAttribute('href', 'http://fanpage.com');
+  });
+
+  it('renders snapshot of focused state', () => {
+    const { getByText } = render(<Link href="https://datacamp.com">Test</Link>);
+
+    const link = getByText('Test').closest('a') as HTMLAnchorElement;
+    fireEvent.focus(link);
+
+    expect(link).toMatchSnapshot();
+  });
+
+  it('accepts ref and could be focused programmatically when link has a "href" attribute', () => {
+    const { container } = render(<TestRefLink />);
+
+    const link = container.querySelector('a');
+
+    expect(link).toHaveFocus();
+  });
+
+  describe('renders snapshot', () => {
+    const { container } = render(
+      <Link href="https://taylor-swift-fanclub.com">
+        Join Taylor Swift Fanclub
+      </Link>,
+    );
+
+    const link = container.querySelector('a');
+
+    expect(link).toMatchSnapshot();
+  });
+
+  describe('renders snapshot of inverted variant', () => {
+    const { container } = render(
+      <Link inverted href="https://taylor-swift-fanclub.com">
+        Join Taylor Swift Fanclub
+      </Link>,
+    );
+
+    const link = container.querySelector('a');
+
+    expect(link).toMatchSnapshot();
+  });
+});

--- a/src/link/index.ts
+++ b/src/link/index.ts
@@ -1,0 +1,1 @@
+export { default as Link } from './link';

--- a/src/link/link.tsx
+++ b/src/link/link.tsx
@@ -1,0 +1,66 @@
+import React, { forwardRef } from 'react';
+import { useFocusRing } from '@react-aria/focus';
+
+import type { PolymorphicRef, PolymorphicComponentProps } from '../utils';
+import { linkStyle, innerContentStyle } from './styles';
+
+type LinkBaseProps = {
+  children: React.ReactNode;
+  inverted?: boolean;
+  iconLeft?: React.ReactNode;
+  iconRight?: React.ReactNode;
+};
+
+type LinkProps<T extends React.ElementType = 'a'> = PolymorphicComponentProps<
+  T,
+  LinkBaseProps
+>;
+
+type LinkComponent = <T extends React.ElementType = 'a'>(
+  props: LinkProps<T>,
+) => JSX.Element | null;
+
+function LinkBase<T extends React.ElementType = 'a'>(
+  {
+    as,
+    inverted = false,
+    iconLeft,
+    iconRight,
+    children,
+    ...restProps
+  }: LinkProps<T>,
+  ref?: PolymorphicRef<T>,
+) {
+  const Element = as || 'a';
+
+  const { focusProps, isFocusVisible } = useFocusRing();
+
+  return (
+    <Element
+      ref={ref}
+      css={linkStyle({
+        inverted,
+        isFocusVisible,
+      })}
+      {...restProps}
+      {...focusProps}
+    >
+      {iconLeft}
+      {
+        <span
+          css={innerContentStyle({
+            hasLeftIcon: !!iconLeft,
+            hasRightIcon: !!iconRight,
+          })}
+        >
+          {children}
+        </span>
+      }
+      {iconRight}
+    </Element>
+  );
+}
+
+const Link: LinkComponent = forwardRef(LinkBase);
+
+export default Link;

--- a/src/link/styles.ts
+++ b/src/link/styles.ts
@@ -1,0 +1,50 @@
+import { css } from '@emotion/react';
+
+import { tokens } from '../tokens';
+
+const linkBaseStyle = css`
+  text-decoration: none;
+  font-family: ${tokens.fontFamilies.sansSerif};
+  font-weight: ${tokens.fontWeights.bold};
+  font-size: ${tokens.fontSizes.medium};
+  line-height: ${tokens.lineHeights.relaxed};
+  outline: 0;
+  border-radius: ${tokens.borderRadius.medium};
+  transition: box-shadow 125ms ease-out;
+
+  &:hover:not(:focus) {
+    text-decoration: underline;
+  }
+`;
+
+type LinkStyleOptions = {
+  inverted: boolean;
+  isFocusVisible: boolean;
+};
+
+export function linkStyle({ inverted, isFocusVisible }: LinkStyleOptions) {
+  return css`
+    ${linkBaseStyle}
+    color: ${inverted ? tokens.colors.blueDark : tokens.colors.blueDarkText};
+
+    ${isFocusVisible &&
+    css`
+      box-shadow: 0 0 0 2px ${tokens.colors.blueDark};
+    `}
+  `;
+}
+
+type InnerContentStyleOptions = {
+  hasLeftIcon: boolean;
+  hasRightIcon: boolean;
+};
+
+export function innerContentStyle({
+  hasLeftIcon,
+  hasRightIcon,
+}: InnerContentStyleOptions) {
+  return css`
+    ${hasLeftIcon && `padding-left: ${tokens.spacing.xsmall};`}
+    ${hasRightIcon && `padding-right: ${tokens.spacing.xsmall};`}
+  `;
+}

--- a/src/paragraph/__tests__/__snapshots__/paragraph.spec.tsx.snap
+++ b/src/paragraph/__tests__/__snapshots__/paragraph.spec.tsx.snap
@@ -14,6 +14,10 @@ exports[`Paragraph renders snapshot of inverted variant primary 1`] = `
   color: #FFFFFF;
 }
 
+.emotion-0:last-of-type {
+  margin-bottom: 0;
+}
+
 <p
   class="emotion-0"
 >
@@ -33,6 +37,10 @@ exports[`Paragraph renders snapshot of inverted variant secondary 1`] = `
   line-height: 1.5;
   margin-bottom: 8px;
   color: #9BA3AB;
+}
+
+.emotion-0:last-of-type {
+  margin-bottom: 0;
 }
 
 <p
@@ -56,6 +64,10 @@ exports[`Paragraph renders snapshot of variant primary 1`] = `
   color: #05192D;
 }
 
+.emotion-0:last-of-type {
+  margin-bottom: 0;
+}
+
 <p
   class="emotion-0"
 >
@@ -75,6 +87,10 @@ exports[`Paragraph renders snapshot of variant secondary 1`] = `
   line-height: 1.5;
   margin-bottom: 8px;
   color: #65707C;
+}
+
+.emotion-0:last-of-type {
+  margin-bottom: 0;
 }
 
 <p

--- a/src/paragraph/__tests__/__snapshots__/paragraph.spec.tsx.snap
+++ b/src/paragraph/__tests__/__snapshots__/paragraph.spec.tsx.snap
@@ -1,0 +1,85 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Paragraph renders snapshot of inverted variant primary 1`] = `
+.emotion-0 {
+  color: #05192D;
+  font-family: Studio-Feixen-Sans,Arial,sans-serif;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 1;
+  margin: 0;
+  padding: 0;
+  line-height: 1.5;
+  margin-bottom: 8px;
+  color: #FFFFFF;
+}
+
+<p
+  class="emotion-0"
+>
+  Test
+</p>
+`;
+
+exports[`Paragraph renders snapshot of inverted variant secondary 1`] = `
+.emotion-0 {
+  color: #05192D;
+  font-family: Studio-Feixen-Sans,Arial,sans-serif;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 1;
+  margin: 0;
+  padding: 0;
+  line-height: 1.5;
+  margin-bottom: 8px;
+  color: #9BA3AB;
+}
+
+<p
+  class="emotion-0"
+>
+  Test
+</p>
+`;
+
+exports[`Paragraph renders snapshot of variant primary 1`] = `
+.emotion-0 {
+  color: #05192D;
+  font-family: Studio-Feixen-Sans,Arial,sans-serif;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 1;
+  margin: 0;
+  padding: 0;
+  line-height: 1.5;
+  margin-bottom: 8px;
+  color: #05192D;
+}
+
+<p
+  class="emotion-0"
+>
+  Test
+</p>
+`;
+
+exports[`Paragraph renders snapshot of variant secondary 1`] = `
+.emotion-0 {
+  color: #05192D;
+  font-family: Studio-Feixen-Sans,Arial,sans-serif;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 1;
+  margin: 0;
+  padding: 0;
+  line-height: 1.5;
+  margin-bottom: 8px;
+  color: #65707C;
+}
+
+<p
+  class="emotion-0"
+>
+  Test
+</p>
+`;

--- a/src/paragraph/__tests__/paragraph-styled.story.tsx
+++ b/src/paragraph/__tests__/paragraph-styled.story.tsx
@@ -1,0 +1,31 @@
+import { css } from '@emotion/react';
+
+import { tokens } from '../../tokens';
+import { Paragraph } from '../index';
+
+const wrapperStyle = css`
+  padding: ${tokens.spacing.medium};
+`;
+
+const customParagraphStyle = css`
+  color: ${tokens.colors.redDarkText};
+  font-size: ${tokens.fontSizes.xlarge};
+`;
+
+function Story() {
+  return (
+    <div css={wrapperStyle}>
+      <Paragraph css={customParagraphStyle}>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+        velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+        occaecat cupidatat non proident, sunt in culpa qui officia deserunt
+        mollit anim id est laborum.
+      </Paragraph>
+    </div>
+  );
+}
+
+export default Story;

--- a/src/paragraph/__tests__/paragraph-variants.story.tsx
+++ b/src/paragraph/__tests__/paragraph-variants.story.tsx
@@ -1,0 +1,68 @@
+import { css } from '@emotion/react';
+
+import { tokens } from '../../tokens';
+import { Paragraph } from '../index';
+
+const wrapperStyle = css`
+  padding: ${tokens.spacing.medium};
+`;
+
+const variants = ['primary', 'secondary'] as const;
+
+const testText1 =
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.';
+
+const testText2 =
+  'Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem.';
+
+function Story() {
+  return (
+    <>
+      {/* Regular */}
+      <div css={wrapperStyle}>
+        {variants.map((variant, index) => {
+          return (
+            <>
+              <Paragraph key={`variant-${index}`} variant={variant}>
+                {testText1}
+              </Paragraph>
+              <Paragraph key={`variant-${index}`} variant={variant}>
+                {testText2}
+              </Paragraph>
+            </>
+          );
+        })}
+      </div>
+      {/* Inverted */}
+      <div
+        css={css`
+          ${wrapperStyle}
+          background-color: ${tokens.colors.navy};
+        `}
+      >
+        {variants.map((variant, index) => {
+          return (
+            <>
+              <Paragraph
+                key={`inverted-variant-${index}`}
+                variant={variant}
+                inverted
+              >
+                {testText1}
+              </Paragraph>
+              <Paragraph
+                key={`inverted-variant-${index}`}
+                variant={variant}
+                inverted
+              >
+                {testText2}
+              </Paragraph>
+            </>
+          );
+        })}
+      </div>
+    </>
+  );
+}
+
+export default Story;

--- a/src/paragraph/__tests__/paragraph-variants.story.tsx
+++ b/src/paragraph/__tests__/paragraph-variants.story.tsx
@@ -5,6 +5,10 @@ import { Paragraph } from '../index';
 
 const wrapperStyle = css`
   padding: ${tokens.spacing.medium};
+
+  &:not(:first-of-type) {
+    padding-top: 0;
+  }
 `;
 
 const variants = ['primary', 'secondary'] as const;
@@ -19,45 +23,34 @@ function Story() {
   return (
     <>
       {/* Regular */}
-      <div css={wrapperStyle}>
-        {variants.map((variant, index) => {
+      <div>
+        {variants.map((variant) => {
           return (
-            <>
-              <Paragraph key={`variant-${index}`} variant={variant}>
-                {testText1}
-              </Paragraph>
-              <Paragraph key={`variant-${index}`} variant={variant}>
-                {testText2}
-              </Paragraph>
-            </>
+            <div key={variant} css={wrapperStyle}>
+              <Paragraph variant={variant}>{testText1}</Paragraph>
+              <Paragraph variant={variant}>{testText2}</Paragraph>
+            </div>
           );
         })}
       </div>
-      {/* Inverted */}
-      <div
-        css={css`
-          ${wrapperStyle}
-          background-color: ${tokens.colors.navy};
-        `}
-      >
-        {variants.map((variant, index) => {
+      <div>
+        {/* Inverted */}
+        {variants.map((variant) => {
           return (
-            <>
-              <Paragraph
-                key={`inverted-variant-${index}`}
-                variant={variant}
-                inverted
-              >
+            <div
+              key={`inverted-${variant}`}
+              css={css`
+                ${wrapperStyle}
+                background-color: ${tokens.colors.navy};
+              `}
+            >
+              <Paragraph variant={variant} inverted>
                 {testText1}
               </Paragraph>
-              <Paragraph
-                key={`inverted-variant-${index}`}
-                variant={variant}
-                inverted
-              >
+              <Paragraph variant={variant} inverted>
                 {testText2}
               </Paragraph>
-            </>
+            </div>
           );
         })}
       </div>

--- a/src/paragraph/__tests__/paragraph-variants.story.tsx
+++ b/src/paragraph/__tests__/paragraph-variants.story.tsx
@@ -33,8 +33,8 @@ function Story() {
           );
         })}
       </div>
+      {/* Inverted */}
       <div>
-        {/* Inverted */}
         {variants.map((variant) => {
           return (
             <div

--- a/src/paragraph/__tests__/paragraph.e2e.ts
+++ b/src/paragraph/__tests__/paragraph.e2e.ts
@@ -1,17 +1,11 @@
 describe('Paragraph', () => {
   it('render all varaints', () => {
     cy.loadStory('paragraph-variants');
-    cy.injectAxe();
-
     cy.get('main').find('p').should('have.length', 8);
-    cy.a11yCheck();
   });
 
   it('renders with custom styles applied', () => {
     cy.loadStory('paragraph-styled');
-    cy.injectAxe();
-
     cy.get('main').find('p').should('have.length', 1);
-    cy.a11yCheck();
   });
 });

--- a/src/paragraph/__tests__/paragraph.e2e.ts
+++ b/src/paragraph/__tests__/paragraph.e2e.ts
@@ -1,0 +1,17 @@
+describe('Paragraph', () => {
+  it('render all varaints', () => {
+    cy.loadStory('paragraph-variants');
+    cy.injectAxe();
+
+    cy.get('main').find('p').should('have.length', 8);
+    cy.a11yCheck();
+  });
+
+  it('renders with custom styles applied', () => {
+    cy.loadStory('paragraph-styled');
+    cy.injectAxe();
+
+    cy.get('main').find('p').should('have.length', 1);
+    cy.a11yCheck();
+  });
+});

--- a/src/paragraph/__tests__/paragraph.spec.tsx
+++ b/src/paragraph/__tests__/paragraph.spec.tsx
@@ -1,0 +1,58 @@
+import { render } from '@testing-library/react';
+
+import { Paragraph } from '../index';
+
+const variants = ['primary', 'secondary'] as const;
+
+describe('Paragraph', () => {
+  it('renders a paragraph containing the text', () => {
+    const { container } = render(
+      <Paragraph>Short paragraph about Taylor Swift.</Paragraph>,
+    );
+
+    const paragraph = container.querySelector('p');
+
+    expect(paragraph).toBeInTheDocument();
+    expect(paragraph).toHaveTextContent('Short paragraph about Taylor Swift.');
+  });
+
+  it('sets the data attribute on the paragraph', () => {
+    const { getByTestId } = render(
+      <Paragraph data-testid="paragraph-22">
+        Short paragraph about Taylor Swift.
+      </Paragraph>,
+    );
+
+    const paragraph = getByTestId('paragraph-22');
+
+    expect(paragraph).toBeInTheDocument();
+  });
+
+  describe('renders snapshot of', () => {
+    variants.forEach((variant) => {
+      it(`variant ${variant}`, () => {
+        const { container } = render(
+          <Paragraph variant={variant}>Test</Paragraph>,
+        );
+
+        const paragraph = container.querySelector('p');
+        expect(paragraph).toMatchSnapshot();
+      });
+    });
+  });
+
+  describe('renders snapshot of inverted', () => {
+    variants.forEach((variant) => {
+      it(`variant ${variant}`, () => {
+        const { container } = render(
+          <Paragraph variant={variant} inverted>
+            Test
+          </Paragraph>,
+        );
+
+        const paragraph = container.querySelector('p');
+        expect(paragraph).toMatchSnapshot();
+      });
+    });
+  });
+});

--- a/src/paragraph/index.ts
+++ b/src/paragraph/index.ts
@@ -1,0 +1,1 @@
+export { default as Paragraph } from './paragraph';

--- a/src/paragraph/paragraph.tsx
+++ b/src/paragraph/paragraph.tsx
@@ -1,0 +1,20 @@
+import { Text } from '../text';
+import { paragraphStyle } from './styles';
+
+type ParagraphProps = {
+  children: React.ReactNode;
+  variant?: 'primary' | 'secondary';
+  inverted?: boolean;
+} & React.HTMLAttributes<HTMLParagraphElement>;
+
+function Paragraph({
+  variant = 'primary',
+  inverted = false,
+  ...restProps
+}: ParagraphProps) {
+  return (
+    <Text as="p" css={paragraphStyle({ variant, inverted })} {...restProps} />
+  );
+}
+
+export default Paragraph;

--- a/src/paragraph/styles.ts
+++ b/src/paragraph/styles.ts
@@ -1,0 +1,37 @@
+import { css } from '@emotion/react';
+
+import { tokens } from '../tokens';
+import Paragraph from './paragraph';
+
+const regularVariantMap = {
+  primary: {
+    color: tokens.colors.navy,
+  },
+  secondary: {
+    color: tokens.colors.navySubtleTextOnLight,
+  },
+};
+
+const invertedVariantMap = {
+  primary: {
+    color: tokens.colors.white,
+  },
+  secondary: {
+    color: tokens.colors.navySubtleTextOnDark,
+  },
+};
+
+type ParagraphStyleOptions = {
+  variant: NonNullable<React.ComponentProps<typeof Paragraph>['variant']>;
+  inverted: boolean;
+};
+
+export function paragraphStyle({ variant, inverted }: ParagraphStyleOptions) {
+  const variantMap = inverted ? invertedVariantMap : regularVariantMap;
+
+  return css`
+    line-height: ${tokens.lineHeights.relaxed};
+    margin-bottom: ${tokens.spacing.small};
+    color: ${variantMap[variant].color};
+  `;
+}

--- a/src/paragraph/styles.ts
+++ b/src/paragraph/styles.ts
@@ -33,5 +33,9 @@ export function paragraphStyle({ variant, inverted }: ParagraphStyleOptions) {
     line-height: ${tokens.lineHeights.relaxed};
     margin-bottom: ${tokens.spacing.small};
     color: ${variantMap[variant].color};
+
+    &:last-of-type {
+      margin-bottom: 0;
+    }
   `;
 }

--- a/src/paragraph/styles.ts
+++ b/src/paragraph/styles.ts
@@ -3,6 +3,8 @@ import { css } from '@emotion/react';
 import { tokens } from '../tokens';
 import Paragraph from './paragraph';
 
+// Mapping between paragraph size and text color
+
 const regularVariantMap = {
   primary: {
     color: tokens.colors.navy,
@@ -20,6 +22,8 @@ const invertedVariantMap = {
     color: tokens.colors.navySubtleTextOnDark,
   },
 };
+
+// Generate paragraph style based on provided variant
 
 type ParagraphStyleOptions = {
   variant: NonNullable<React.ComponentProps<typeof Paragraph>['variant']>;

--- a/src/text/__tests__/__snapshots__/text.spec.tsx.snap
+++ b/src/text/__tests__/__snapshots__/text.spec.tsx.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Text renders snapshot 1`] = `
+.emotion-0 {
+  color: #05192D;
+  font-family: Studio-Feixen-Sans,Arial,sans-serif;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 1;
+  margin: 0;
+  padding: 0;
+}
+
+<span
+  class="emotion-0"
+>
+  Definitely not Taylor Swift
+</span>
+`;

--- a/src/text/__tests__/text-basic.story.tsx
+++ b/src/text/__tests__/text-basic.story.tsx
@@ -1,0 +1,18 @@
+import { css } from '@emotion/react';
+
+import { tokens } from '../../tokens';
+import { Text } from '../index';
+
+const wrapperStyle = css`
+  padding: ${tokens.spacing.medium};
+`;
+
+function Story() {
+  return (
+    <div css={wrapperStyle}>
+      <Text>Basic short text content</Text>
+    </div>
+  );
+}
+
+export default Story;

--- a/src/text/__tests__/text-styled.story.tsx
+++ b/src/text/__tests__/text-styled.story.tsx
@@ -1,0 +1,23 @@
+import { css } from '@emotion/react';
+
+import { tokens } from '../../tokens';
+import { Text } from '../index';
+
+const wrapperStyle = css`
+  padding: ${tokens.spacing.medium};
+`;
+
+const customTextStyle = css`
+  color: ${tokens.colors.red};
+  font-size: ${tokens.fontSizes.xlarge};
+`;
+
+function Story() {
+  return (
+    <div css={wrapperStyle}>
+      <Text css={customTextStyle}>Custom style text</Text>
+    </div>
+  );
+}
+
+export default Story;

--- a/src/text/__tests__/text.e2e.ts
+++ b/src/text/__tests__/text.e2e.ts
@@ -1,0 +1,17 @@
+describe('Text', () => {
+  it('renders a basic text', () => {
+    cy.loadStory('text-basic');
+    cy.injectAxe();
+
+    cy.findByText('Basic short text content');
+    cy.a11yCheck();
+  });
+
+  it('renders text with custom styles applied', () => {
+    cy.loadStory('text-styled');
+    cy.injectAxe();
+
+    cy.get('span').should('have.length', 1);
+    cy.a11yCheck();
+  });
+});

--- a/src/text/__tests__/text.e2e.ts
+++ b/src/text/__tests__/text.e2e.ts
@@ -7,7 +7,7 @@ describe('Text', () => {
     cy.a11yCheck();
   });
 
-  it('renders text with custom styles applied', () => {
+  it('renders with custom styles applied', () => {
     cy.loadStory('text-styled');
     cy.injectAxe();
 

--- a/src/text/__tests__/text.e2e.ts
+++ b/src/text/__tests__/text.e2e.ts
@@ -3,7 +3,7 @@ describe('Text', () => {
     cy.loadStory('text-basic');
     cy.injectAxe();
 
-    cy.findByText('Basic short text content');
+    cy.findByText('Basic short text content').should('exist');
     cy.a11yCheck();
   });
 

--- a/src/text/__tests__/text.e2e.ts
+++ b/src/text/__tests__/text.e2e.ts
@@ -1,17 +1,11 @@
 describe('Text', () => {
   it('renders a basic text', () => {
     cy.loadStory('text-basic');
-    cy.injectAxe();
-
     cy.findByText('Basic short text content').should('exist');
-    cy.a11yCheck();
   });
 
   it('renders with custom styles applied', () => {
     cy.loadStory('text-styled');
-    cy.injectAxe();
-
     cy.get('span').should('have.length', 1);
-    cy.a11yCheck();
   });
 });

--- a/src/text/__tests__/text.spec.tsx
+++ b/src/text/__tests__/text.spec.tsx
@@ -1,0 +1,42 @@
+import { render } from '@testing-library/react';
+
+import { Text } from '../index';
+
+describe('Text', () => {
+  it('renders a span element containing the text', () => {
+    const { container } = render(<Text>Taylor Swift Fanclub</Text>);
+
+    const text = container.querySelector('span');
+
+    expect(text).toBeInTheDocument();
+    expect(text).toHaveTextContent('Taylor Swift Fanclub');
+  });
+
+  it('sets the data attribute on the text element', () => {
+    const { getByTestId } = render(
+      <Text data-testid="taylors-text">Taylor Swift Fanclub</Text>,
+    );
+
+    const text = getByTestId('taylors-text');
+
+    expect(text).toBeInTheDocument();
+  });
+
+  it('renders an element passed via "as" prop', () => {
+    const { container } = render(<Text as="p">Taylor Swift Fanclub</Text>);
+
+    const text = container.querySelector('p');
+
+    expect(text).toBeInTheDocument();
+    expect(text).toHaveTextContent('Taylor Swift Fanclub');
+  });
+
+  it('renders snapshot', () => {
+    const { getByText } = render(<Text>Definitely not Taylor Swift</Text>);
+
+    const text = getByText(/taylor swift/i);
+
+    expect(text).toBeInTheDocument();
+    expect(text).toMatchSnapshot();
+  });
+});

--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -1,0 +1,1 @@
+export { default as Text } from './text';

--- a/src/text/styles.ts
+++ b/src/text/styles.ts
@@ -4,6 +4,7 @@ import { tokens } from '../tokens';
 
 export function textStyle() {
   return css`
+    color: ${tokens.colors.navy};
     font-family: ${tokens.fontFamilies.sansSerif};
     font-size: ${tokens.fontSizes.medium};
     font-weight: ${tokens.fontWeights.regular};

--- a/src/text/styles.ts
+++ b/src/text/styles.ts
@@ -1,0 +1,14 @@
+import { css } from '@emotion/react';
+
+import { tokens } from '../tokens';
+
+export function textStyle() {
+  return css`
+    font-family: ${tokens.fontFamilies.sansSerif};
+    font-size: ${tokens.fontSizes.medium};
+    font-weight: ${tokens.fontWeights.regular};
+    line-height: ${tokens.lineHeights.tight};
+    margin: 0;
+    padding: 0;
+  `;
+}

--- a/src/text/text.tsx
+++ b/src/text/text.tsx
@@ -1,0 +1,32 @@
+import React, { forwardRef } from 'react';
+
+import type { PolymorphicRef, PolymorphicComponentProps } from '../utils';
+import { textStyle } from './styles';
+
+type TextBaseProps = {
+  children: React.ReactNode;
+};
+
+type TextProps<T extends React.ElementType = 'span'> =
+  PolymorphicComponentProps<T, TextBaseProps>;
+
+type TextComponent = <T extends React.ElementType = 'span'>(
+  props: TextProps<T>,
+) => JSX.Element | null;
+
+function TextBase<T extends React.ElementType = 'span'>(
+  { as, children, ...restProps }: TextProps<T>,
+  ref?: PolymorphicRef<T>,
+) {
+  const Element = as || 'span';
+
+  return (
+    <Element ref={ref} css={textStyle()} {...restProps}>
+      {children}
+    </Element>
+  );
+}
+
+const Text: TextComponent = forwardRef(TextBase);
+
+export default Text;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,2 @@
+export type { PolymorphicRef, PolymorphicComponentProps } from './types';
 export { default as hexToRgba } from './hex-to-rgba';

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,0 +1,8 @@
+export type PolymorphicRef<T extends React.ElementType> =
+  React.ComponentPropsWithRef<T>['ref'];
+
+export type PolymorphicComponentProps<
+  T extends React.ElementType,
+  P extends Record<string, unknown>,
+> = Omit<React.ComponentPropsWithoutRef<T>, keyof P> &
+  P & { as?: T; ref?: PolymorphicRef<T> };


### PR DESCRIPTION
# [WF-532](https://datacamp.atlassian.net/browse/WF-532), [WF-533](https://datacamp.atlassian.net/browse/WF-533), [WF-555](https://datacamp.atlassian.net/browse/WF-555), [WF-556](https://datacamp.atlassian.net/browse/WF-556), [WF-557](https://datacamp.atlassian.net/browse/WF-557), [WF-558](https://datacamp.atlassian.net/browse/WF-558)

Implemented following core typography components:
* Heading
* Paragraph
* Chapeau
* Display
* Code and CodeBlock
* inline text Link
* generic Text (base for building other components)

<img width="1193" alt="typography-components" src="https://user-images.githubusercontent.com/20565536/132657570-07be1eb7-8f01-4daa-83ed-dde18d083876.png">

✅ Testes in recent Chrome, FF, and Safari.