### PR TITLE
[WF-598] SideNavigation and Drawer adjustments

### DIFF
--- a/doc-site/examples/side-navigation/advanced-usage.tsx
+++ b/doc-site/examples/side-navigation/advanced-usage.tsx
@@ -116,12 +116,8 @@ function Example() {
             </NavItem>
           </SideNav.Category>
           <SideNav.Category label="Learn">
-            <NavItem
-              href="#custom-tracks"
-              iconLeft={<Branch />}
-              iconRight={<Branch />}
-            >
-              Custom Tracks Custom Custom Tracks
+            <NavItem href="#custom-tracks" iconLeft={<Branch />}>
+              Custom Tracks With Very Long Content
             </NavItem>
             <NavItem href="#assignments" iconLeft={<Assignment />}>
               Assignments

--- a/doc-site/pages/components/content-container.mdx
+++ b/doc-site/pages/components/content-container.mdx
@@ -17,7 +17,7 @@ The content container positions the main content on the page depending on the vi
 - for phones, and small tablets (viewport size below `medium` breakpoint), padding around content of `medium` size is used
 - for desktop, and large tablets (for viewport size above `medium` breakpoint), padding is increased to `xlarge` size
 
-You may also check a [little demo](https://waffles-grid.surge.sh/) which should help to understand relationship between `ContentContainer`, `SideNavigation`, and grid.
+You may check a [little demo](https://waffles-grid.surge.sh/) which should help to understand relationship between `ContentContainer`, `SideNavigation`, and grid. If you're curious about implementation details there is also [repository](https://github.com/datacamp-engineering/waffles-demo-grid) with a demo's source code.
 
 ## Props
 

--- a/src/drawer/__tests__/__snapshots__/drawer.spec.tsx.snap
+++ b/src/drawer/__tests__/__snapshots__/drawer.spec.tsx.snap
@@ -3,10 +3,10 @@
 exports[`Drawer renders snapshot when drawer is placed to the left 1`] = `
 @keyframes animation-0 {
   from {
-    -webkit-transform: translateX(-300px);
-    -moz-transform: translateX(-300px);
-    -ms-transform: translateX(-300px);
-    transform: translateX(-300px);
+    -webkit-transform: translateX(-356px);
+    -moz-transform: translateX(-356px);
+    -ms-transform: translateX(-356px);
+    transform: translateX(-356px);
   }
 
   to {
@@ -19,10 +19,10 @@ exports[`Drawer renders snapshot when drawer is placed to the left 1`] = `
 
 @keyframes animation-0 {
   from {
-    -webkit-transform: translateX(-300px);
-    -moz-transform: translateX(-300px);
-    -ms-transform: translateX(-300px);
-    transform: translateX(-300px);
+    -webkit-transform: translateX(-356px);
+    -moz-transform: translateX(-356px);
+    -ms-transform: translateX(-356px);
+    transform: translateX(-356px);
   }
 
   to {
@@ -72,18 +72,19 @@ exports[`Drawer renders snapshot when drawer is placed to the left 1`] = `
   outline: 0;
   overflow: hidden;
   pointer-events: all;
-  width: 300px;
+  width: calc(100vw - 64px);
+  max-width: 356;
   -webkit-transform: translateX(
-        -300px
+        -356px
       );
   -moz-transform: translateX(
-        -300px
+        -356px
       );
   -ms-transform: translateX(
-        -300px
+        -356px
       );
   transform: translateX(
-        -300px
+        -356px
       );
   -webkit-animation: animation-0 200ms cubic-bezier(0, 0, 0.6, 1) forwards;
   animation: animation-0 200ms cubic-bezier(0, 0, 0.6, 1) forwards;
@@ -101,7 +102,10 @@ exports[`Drawer renders snapshot when drawer is placed to the left 1`] = `
 
 @media screen and (min-width: 480px) {
   .emotion-0 {
-    width: 600px;
+    width: min(
+            calc(100vw - 64px),
+            600px
+          );
     -webkit-transform: translateX(
             -600px
           );
@@ -475,10 +479,10 @@ exports[`Drawer renders snapshot when drawer is placed to the left 1`] = `
 exports[`Drawer renders snapshot when drawer is placed to the right 1`] = `
 @keyframes animation-0 {
   from {
-    -webkit-transform: translateX(300px);
-    -moz-transform: translateX(300px);
-    -ms-transform: translateX(300px);
-    transform: translateX(300px);
+    -webkit-transform: translateX(356px);
+    -moz-transform: translateX(356px);
+    -ms-transform: translateX(356px);
+    transform: translateX(356px);
   }
 
   to {
@@ -491,10 +495,10 @@ exports[`Drawer renders snapshot when drawer is placed to the right 1`] = `
 
 @keyframes animation-0 {
   from {
-    -webkit-transform: translateX(300px);
-    -moz-transform: translateX(300px);
-    -ms-transform: translateX(300px);
-    transform: translateX(300px);
+    -webkit-transform: translateX(356px);
+    -moz-transform: translateX(356px);
+    -ms-transform: translateX(356px);
+    transform: translateX(356px);
   }
 
   to {
@@ -544,18 +548,19 @@ exports[`Drawer renders snapshot when drawer is placed to the right 1`] = `
   outline: 0;
   overflow: hidden;
   pointer-events: all;
-  width: 300px;
+  width: calc(100vw - 64px);
+  max-width: 356;
   -webkit-transform: translateX(
-        300px
+        356px
       );
   -moz-transform: translateX(
-        300px
+        356px
       );
   -ms-transform: translateX(
-        300px
+        356px
       );
   transform: translateX(
-        300px
+        356px
       );
   -webkit-animation: animation-0 200ms cubic-bezier(0, 0, 0.6, 1) forwards;
   animation: animation-0 200ms cubic-bezier(0, 0, 0.6, 1) forwards;
@@ -573,7 +578,10 @@ exports[`Drawer renders snapshot when drawer is placed to the right 1`] = `
 
 @media screen and (min-width: 480px) {
   .emotion-0 {
-    width: 600px;
+    width: min(
+            calc(100vw - 64px),
+            600px
+          );
     -webkit-transform: translateX(
             600px
           );

--- a/src/drawer/panel.tsx
+++ b/src/drawer/panel.tsx
@@ -24,7 +24,7 @@ function Panel({
     <>
       {/* Background panel which spans whole device heigh */}
       <div css={panelStyle({ isVisible, placement })} />
-      {/* Content only wrapper allows buttons to be fixed at the bottom and be always visible at once*/}
+      {/* Content only wrapper allows buttons to be fixed at the bottom and be always visible at once */}
       <section
         {...restProps}
         aria-modal

--- a/src/drawer/styles.ts
+++ b/src/drawer/styles.ts
@@ -14,8 +14,8 @@ type PanelStyleOptions = {
   placement: NonNullable<React.ComponentProps<typeof Drawer>['placement']>;
 };
 
-const PANEL_MAX_WIDTH_BELOW_MEDIUM_BREKPOINT = 356;
-const PANEL_WIDTH_ABOVE_SMALL_BREKPOINT = 600;
+const PANEL_MAX_WIDTH_BELOW_MEDIUM_BREAKPOINT = 356;
+const PANEL_WIDTH_ABOVE_SMALL_BREAKPOINT = 600;
 
 function basePanelStyle({ isVisible, placement }: PanelStyleOptions) {
   const horizontalDirection = placement === 'left' ? -1 : 1;
@@ -28,18 +28,18 @@ function basePanelStyle({ isVisible, placement }: PanelStyleOptions) {
     overflow: hidden;
     pointer-events: all;
     width: calc(100vw - ${tokens.spacing.xxlarge});
-    max-width: ${PANEL_MAX_WIDTH_BELOW_MEDIUM_BREKPOINT};
+    max-width: ${PANEL_MAX_WIDTH_BELOW_MEDIUM_BREAKPOINT};
     // Animation
     transform: translateX(
-      ${horizontalDirection * PANEL_MAX_WIDTH_BELOW_MEDIUM_BREKPOINT}px
+      ${horizontalDirection * PANEL_MAX_WIDTH_BELOW_MEDIUM_BREAKPOINT}px
     );
     animation: ${isVisible
         ? panelEnter({
-            offset: PANEL_MAX_WIDTH_BELOW_MEDIUM_BREKPOINT,
+            offset: PANEL_MAX_WIDTH_BELOW_MEDIUM_BREAKPOINT,
             slideFrom: placement,
           })
         : panelExit({
-            offset: PANEL_MAX_WIDTH_BELOW_MEDIUM_BREKPOINT,
+            offset: PANEL_MAX_WIDTH_BELOW_MEDIUM_BREAKPOINT,
             slideFrom: placement,
           })}
       200ms cubic-bezier(0, 0, 0.6, 1) forwards;
@@ -47,19 +47,19 @@ function basePanelStyle({ isVisible, placement }: PanelStyleOptions) {
     ${mediaQuery.aboveSmall} {
       width: min(
         calc(100vw - ${tokens.spacing.xxlarge}),
-        ${PANEL_WIDTH_ABOVE_SMALL_BREKPOINT}px
+        ${PANEL_WIDTH_ABOVE_SMALL_BREAKPOINT}px
       );
       // Animation
       transform: translateX(
-        ${horizontalDirection * PANEL_WIDTH_ABOVE_SMALL_BREKPOINT}px
+        ${horizontalDirection * PANEL_WIDTH_ABOVE_SMALL_BREAKPOINT}px
       );
       animation: ${isVisible
           ? panelEnter({
-              offset: PANEL_WIDTH_ABOVE_SMALL_BREKPOINT,
+              offset: PANEL_WIDTH_ABOVE_SMALL_BREAKPOINT,
               slideFrom: placement,
             })
           : panelExit({
-              offset: PANEL_WIDTH_ABOVE_SMALL_BREKPOINT,
+              offset: PANEL_WIDTH_ABOVE_SMALL_BREAKPOINT,
               slideFrom: placement,
             })}
         200ms cubic-bezier(0, 0, 0.6, 1) forwards;

--- a/src/drawer/styles.ts
+++ b/src/drawer/styles.ts
@@ -14,7 +14,7 @@ type PanelStyleOptions = {
   placement: NonNullable<React.ComponentProps<typeof Drawer>['placement']>;
 };
 
-const PANEL_WIDTH_BELOW_SMALL_BREKPOINT = 300;
+const PANEL_MAX_WIDTH_BELOW_MEDIUM_BREKPOINT = 356;
 const PANEL_WIDTH_ABOVE_SMALL_BREKPOINT = 600;
 
 function basePanelStyle({ isVisible, placement }: PanelStyleOptions) {
@@ -27,24 +27,28 @@ function basePanelStyle({ isVisible, placement }: PanelStyleOptions) {
     outline: 0;
     overflow: hidden;
     pointer-events: all;
-    width: ${PANEL_WIDTH_BELOW_SMALL_BREKPOINT}px;
+    width: calc(100vw - ${tokens.spacing.xxlarge});
+    max-width: ${PANEL_MAX_WIDTH_BELOW_MEDIUM_BREKPOINT};
     // Animation
     transform: translateX(
-      ${horizontalDirection * PANEL_WIDTH_BELOW_SMALL_BREKPOINT}px
+      ${horizontalDirection * PANEL_MAX_WIDTH_BELOW_MEDIUM_BREKPOINT}px
     );
     animation: ${isVisible
         ? panelEnter({
-            offset: PANEL_WIDTH_BELOW_SMALL_BREKPOINT,
+            offset: PANEL_MAX_WIDTH_BELOW_MEDIUM_BREKPOINT,
             slideFrom: placement,
           })
         : panelExit({
-            offset: PANEL_WIDTH_BELOW_SMALL_BREKPOINT,
+            offset: PANEL_MAX_WIDTH_BELOW_MEDIUM_BREKPOINT,
             slideFrom: placement,
           })}
       200ms cubic-bezier(0, 0, 0.6, 1) forwards;
 
     ${mediaQuery.aboveSmall} {
-      width: ${PANEL_WIDTH_ABOVE_SMALL_BREKPOINT}px;
+      width: min(
+        calc(100vw - ${tokens.spacing.xxlarge}),
+        ${PANEL_WIDTH_ABOVE_SMALL_BREKPOINT}px
+      );
       // Animation
       transform: translateX(
         ${horizontalDirection * PANEL_WIDTH_ABOVE_SMALL_BREKPOINT}px

--- a/src/side-navigation/animated-sidebar.tsx
+++ b/src/side-navigation/animated-sidebar.tsx
@@ -3,14 +3,15 @@ import React from 'react';
 import { Portal } from '../portal';
 import { useAnimateTransition } from '../hooks';
 
-import { animatedSidebarStyle } from './styles';
+import { animatedSidebarStyle, animatedSidebarContentStyle } from './styles';
 import { useSidebar } from './sidebar-context';
 import Overlay from './overlay';
 import CloseButton from './close-button';
 
 type AnimatedSidebarProps = React.HTMLAttributes<HTMLDivElement>;
 
-function AnimatedSidebar(props: AnimatedSidebarProps) {
+// Incorporate two animated containers to make it work nicely on iOS
+function AnimatedSidebar({ children, ...restProps }: AnimatedSidebarProps) {
   const { isOpen } = useSidebar();
   const isAnimating = useAnimateTransition(isOpen, 300);
 
@@ -20,7 +21,15 @@ function AnimatedSidebar(props: AnimatedSidebarProps) {
         <>
           <Overlay />
           <CloseButton />
-          <div {...props} css={animatedSidebarStyle({ isVisible: isOpen })} />
+          {/* Background sidebar which spans whole device heigh */}
+          <div
+            {...restProps}
+            css={animatedSidebarStyle({ isVisible: isOpen })}
+          />
+          {/* Content only wrapper animated separetely */}
+          <div css={animatedSidebarContentStyle({ isVisible: isOpen })}>
+            {children}
+          </div>
         </>
       )}
     </Portal>

--- a/src/side-navigation/animated-sidebar.tsx
+++ b/src/side-navigation/animated-sidebar.tsx
@@ -21,7 +21,7 @@ function AnimatedSidebar({ children, ...restProps }: AnimatedSidebarProps) {
         <>
           <Overlay />
           <CloseButton />
-          {/* Background sidebar which spans whole device heigh */}
+          {/* Background sidebar which spans whole device height */}
           <div
             {...restProps}
             css={animatedSidebarStyle({ isVisible: isOpen })}

--- a/src/side-navigation/styles.ts
+++ b/src/side-navigation/styles.ts
@@ -67,25 +67,46 @@ type AnimatedSidebarStyleOptions = {
 };
 
 // Mobile sidebar (displayed below medium breakpoint)
-export function animatedSidebarStyle({
-  isVisible,
-}: AnimatedSidebarStyleOptions) {
+
+function baseAnimatedSidebarStyle({ isVisible }: AnimatedSidebarStyleOptions) {
   return css`
     position: fixed;
-    display: flex;
-    flex-direction: column;
     width: calc(100vw - ${tokens.spacing.xxlarge});
     max-width: ${SIDEBAR_MAX_WIDTH_BELOW_MEDIUM_BREKPOINT}px;
     top: 0;
     left: 0;
-    height: 100vh;
-    @supports (height: 100dvh) {
-      height: 100dvh;
-    }
+    // Animation
+    transform: translateX(-${SIDEBAR_MAX_WIDTH_BELOW_MEDIUM_BREKPOINT}px);
+    animation: ${isVisible
+        ? sidebarEnter({ offset: SIDEBAR_MAX_WIDTH_BELOW_MEDIUM_BREKPOINT })
+        : sidebarExit({ offset: SIDEBAR_MAX_WIDTH_BELOW_MEDIUM_BREKPOINT })}
+      200ms ease-out forwards;
+  `;
+}
+
+export function animatedSidebarStyle({
+  isVisible,
+}: AnimatedSidebarStyleOptions) {
+  return css`
+    ${baseAnimatedSidebarStyle({ isVisible })}
     z-index: ${tokens.zIndex.modal};
+    height: 100vh;
     background-color: ${tokens.colors.navy};
     border-right: ${tokens.borderWidth.thin} solid
       ${hexToRgba(tokens.colors.white, 0.2)};
+    overflow: hidden;
+  `;
+}
+
+export function animatedSidebarContentStyle({
+  isVisible,
+}: AnimatedSidebarStyleOptions) {
+  return css`
+    ${baseAnimatedSidebarStyle({ isVisible })}
+    z-index: ${tokens.zIndex.modal + 10};
+    display: flex;
+    flex-direction: column;
+    bottom: 0; // Position bottom of sidebar just above browser bar on iOS
     overflow-y: auto;
     overflow-x: hidden;
     scrollbar-width: none;
@@ -95,12 +116,6 @@ export function animatedSidebarStyle({
       width: 0;
       height: 0;
     }
-    // Animation
-    transform: translateX(-${SIDEBAR_MAX_WIDTH_BELOW_MEDIUM_BREKPOINT}px);
-    animation: ${isVisible
-        ? sidebarEnter({ offset: SIDEBAR_MAX_WIDTH_BELOW_MEDIUM_BREKPOINT })
-        : sidebarExit({ offset: SIDEBAR_MAX_WIDTH_BELOW_MEDIUM_BREKPOINT })}
-      200ms ease-out forwards;
   `;
 }
 

--- a/src/side-navigation/styles.ts
+++ b/src/side-navigation/styles.ts
@@ -79,6 +79,9 @@ export function animatedSidebarStyle({
     top: 0;
     left: 0;
     height: 100vh;
+    @supports (height: 100dvh) {
+      height: 100dvh;
+    }
     z-index: ${tokens.zIndex.modal};
     background-color: ${tokens.colors.navy};
     border-right: ${tokens.borderWidth.thin} solid

--- a/src/side-navigation/styles.ts
+++ b/src/side-navigation/styles.ts
@@ -47,14 +47,14 @@ export function listStyle() {
   `;
 }
 
-const SIDEBAR_MAX_WIDTH_BELOW_MEDIUM_BREKPOINT = 356;
-const SIDEBAR_WIDTH_ABOVE_MEDIUM_BREKPOINT = 230;
+const SIDEBAR_MAX_WIDTH_BELOW_MEDIUM_BREAKPOINT = 356;
+const SIDEBAR_WIDTH_ABOVE_MEDIUM_BREAKPOINT = 230;
 
 // Regular sidebar (displayed above medium breakpoint)
 export function sidebarStyle() {
   return css`
-    width: ${SIDEBAR_WIDTH_ABOVE_MEDIUM_BREKPOINT}px;
-    min-width: ${SIDEBAR_WIDTH_ABOVE_MEDIUM_BREKPOINT}px;
+    width: ${SIDEBAR_WIDTH_ABOVE_MEDIUM_BREAKPOINT}px;
+    min-width: ${SIDEBAR_WIDTH_ABOVE_MEDIUM_BREAKPOINT}px;
     min-height: 100%;
     background-color: ${tokens.colors.navy};
     display: flex;
@@ -72,14 +72,14 @@ function baseAnimatedSidebarStyle({ isVisible }: AnimatedSidebarStyleOptions) {
   return css`
     position: fixed;
     width: calc(100vw - ${tokens.spacing.xxlarge});
-    max-width: ${SIDEBAR_MAX_WIDTH_BELOW_MEDIUM_BREKPOINT}px;
+    max-width: ${SIDEBAR_MAX_WIDTH_BELOW_MEDIUM_BREAKPOINT}px;
     top: 0;
     left: 0;
     // Animation
-    transform: translateX(-${SIDEBAR_MAX_WIDTH_BELOW_MEDIUM_BREKPOINT}px);
+    transform: translateX(-${SIDEBAR_MAX_WIDTH_BELOW_MEDIUM_BREAKPOINT}px);
     animation: ${isVisible
-        ? sidebarEnter({ offset: SIDEBAR_MAX_WIDTH_BELOW_MEDIUM_BREKPOINT })
-        : sidebarExit({ offset: SIDEBAR_MAX_WIDTH_BELOW_MEDIUM_BREKPOINT })}
+        ? sidebarEnter({ offset: SIDEBAR_MAX_WIDTH_BELOW_MEDIUM_BREAKPOINT })
+        : sidebarExit({ offset: SIDEBAR_MAX_WIDTH_BELOW_MEDIUM_BREAKPOINT })}
       200ms ease-out forwards;
   `;
 }
@@ -289,7 +289,7 @@ export function closeButtonStyle({ isVisible }: ButtonStyleOptions) {
     left: min(
       calc(100vw - ${tokens.spacing.xxlarge} + ${tokens.spacing.small}),
       calc(
-        ${SIDEBAR_MAX_WIDTH_BELOW_MEDIUM_BREKPOINT}px + ${tokens.spacing.small}
+        ${SIDEBAR_MAX_WIDTH_BELOW_MEDIUM_BREAKPOINT}px + ${tokens.spacing.small}
       )
     );
     z-index: ${tokens.zIndex.modal};

--- a/src/side-navigation/styles.ts
+++ b/src/side-navigation/styles.ts
@@ -47,7 +47,7 @@ export function listStyle() {
   `;
 }
 
-const SIDEBAR_WIDTH_BELOW_MEDIUM_BREKPOINT = 300;
+const SIDEBAR_MAX_WIDTH_BELOW_MEDIUM_BREKPOINT = 356;
 const SIDEBAR_WIDTH_ABOVE_MEDIUM_BREKPOINT = 230;
 
 // Regular sidebar (displayed above medium breakpoint)
@@ -74,7 +74,8 @@ export function animatedSidebarStyle({
     position: fixed;
     display: flex;
     flex-direction: column;
-    width: ${SIDEBAR_WIDTH_BELOW_MEDIUM_BREKPOINT}px;
+    width: calc(100vw - ${tokens.spacing.xxlarge});
+    max-width: ${SIDEBAR_MAX_WIDTH_BELOW_MEDIUM_BREKPOINT}px;
     top: 0;
     left: 0;
     height: 100vh;
@@ -92,10 +93,10 @@ export function animatedSidebarStyle({
       height: 0;
     }
     // Animation
-    transform: translateX(-${SIDEBAR_WIDTH_BELOW_MEDIUM_BREKPOINT}px);
+    transform: translateX(-${SIDEBAR_MAX_WIDTH_BELOW_MEDIUM_BREKPOINT}px);
     animation: ${isVisible
-        ? sidebarEnter({ offset: SIDEBAR_WIDTH_BELOW_MEDIUM_BREKPOINT })
-        : sidebarExit({ offset: SIDEBAR_WIDTH_BELOW_MEDIUM_BREKPOINT })}
+        ? sidebarEnter({ offset: SIDEBAR_MAX_WIDTH_BELOW_MEDIUM_BREKPOINT })
+        : sidebarExit({ offset: SIDEBAR_MAX_WIDTH_BELOW_MEDIUM_BREKPOINT })}
       200ms ease-out forwards;
   `;
 }
@@ -266,7 +267,13 @@ export function closeButtonStyle({ isVisible }: ButtonStyleOptions) {
   return css`
     position: fixed;
     bottom: ${tokens.spacing.medium};
-    left: 308px;
+    // Calculate button position next to sidebar depending on display size
+    left: min(
+      calc(100vw - ${tokens.spacing.xxlarge} + ${tokens.spacing.small}),
+      calc(
+        ${SIDEBAR_MAX_WIDTH_BELOW_MEDIUM_BREKPOINT}px + ${tokens.spacing.small}
+      )
+    );
     z-index: ${tokens.zIndex.modal};
     display: flex;
     align-items: center;

--- a/src/tokens/__tests__/__snapshots__/tokens.spec.ts.snap
+++ b/src/tokens/__tests__/__snapshots__/tokens.spec.ts.snap
@@ -115,6 +115,7 @@ Object {
     "small": "8px",
     "xlarge": "32px",
     "xsmall": "4px",
+    "xxlarge": "64px",
   },
   "zIndex": Object {
     "default": 1,

--- a/src/tokens/tokens.json
+++ b/src/tokens/tokens.json
@@ -9,7 +9,8 @@
     "small": "8px",
     "medium": "16px",
     "large": "24px",
-    "xlarge": "32px"
+    "xlarge": "32px",
+    "xxlarge": "64px"
   },
   "colors": {
     "primary": {

--- a/src/tokens/tokens.ts
+++ b/src/tokens/tokens.ts
@@ -6,6 +6,7 @@ const tokens = {
     medium: '16px',
     large: '24px',
     xlarge: '32px',
+    xxlarge: '64px',
   },
   colors: {
     navyLight: '#213147',


### PR DESCRIPTION
# SideNavigation and Drawer width adjustments on mobile, iOS height fix for SideNavigation

## [WF-598](https://datacamp.atlassian.net/browse/WF-598)
## [WF-587](https://datacamp.atlassian.net/browse/WF-587)

## Changes

### 🚀 Major Changes

- Updated the way how _width_ is calculated for `SideNavigation` and `Drawer` on mobile. Previously it was fixed 300px width, but now it is screen width with a small gap left to the right of panel (with max width being 356px). Everything is done with CSS.
- Added `xxlarge` spacing token.

### 🔧 Minor Changes

- Fixed the issues with `SideNavigation` height on iOS, when some portion of the bottom part of menu was cut. The solution is a bit creative: there are 2 fixed positioned panels animated in sync, one is background with `100vh` height and second one has position `bottom` set to 0. That way content is always visible and above browser bar on iOS. With new measurements units (such as `dvh`) it will be possible to simplify it, but right now they are not widely supported (basically work only in Safari iOS15+).

_Tested in Chrome & Safari on various iPhones, tested in Chrome on Android, tested in Chrome & Edge on Windows._

## Screenshot(s):

Updated width of SideNavigation and Drawer:
Recording: https://user-images.githubusercontent.com/20565536/171159603-039d2c26-d786-43bd-80a3-5bca17508f6d.mp4

On iPhone 11 (iOS13):
<img width="447" alt="iphone11-ios13" src="https://user-images.githubusercontent.com/20565536/171159738-75cfe2e9-6922-49b8-b9f4-bc3216991e25.png">

On Samsung Galaxy9:
<img width="475" alt="samsung-galaxy9" src="https://user-images.githubusercontent.com/20565536/171159781-35732984-981a-4fb0-ae26-2c2add6af9d8.png">

On iPhone 12 (iOS15):
![ios-fixed](https://user-images.githubusercontent.com/20565536/171159836-06a24dab-ec70-484b-a169-23a0ff220878.png)

