### PR TITLE
[WF-597] Scrollable Tabs on all devices

### DIFF
--- a/src/tabs/__tests__/__snapshots__/tabs.spec.tsx.snap
+++ b/src/tabs/__tests__/__snapshots__/tabs.spec.tsx.snap
@@ -18,15 +18,6 @@ exports[`Tabs renders snapshot 1`] = `
   height: 0;
 }
 
-@media screen and (min-width: 480px) {
-  .emotion-0 {
-    overflow-y: visible;
-    overflow-x: visible;
-    -webkit-mask-image: none;
-    mask-image: none;
-  }
-}
-
 .emotion-1 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -36,17 +27,6 @@ exports[`Tabs renders snapshot 1`] = `
   padding-left: 0;
   padding-right: 64px;
   border-bottom: 2px solid rgba(5, 25, 45, 0.15);
-}
-
-@media screen and (min-width: 480px) {
-  .emotion-1 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    padding-left: 0;
-    padding-right: 0;
-  }
 }
 
 .emotion-2 {
@@ -232,15 +212,6 @@ exports[`Tabs renders snapshot of inverted 1`] = `
   height: 0;
 }
 
-@media screen and (min-width: 480px) {
-  .emotion-0 {
-    overflow-y: visible;
-    overflow-x: visible;
-    -webkit-mask-image: none;
-    mask-image: none;
-  }
-}
-
 .emotion-1 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -250,17 +221,6 @@ exports[`Tabs renders snapshot of inverted 1`] = `
   padding-left: 0;
   padding-right: 64px;
   border-bottom: 2px solid rgba(255, 255, 255, 0.15);
-}
-
-@media screen and (min-width: 480px) {
-  .emotion-1 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    padding-left: 0;
-    padding-right: 0;
-  }
 }
 
 .emotion-2 {

--- a/src/tabs/__tests__/tabs-long.story.tsx
+++ b/src/tabs/__tests__/tabs-long.story.tsx
@@ -1,33 +1,36 @@
-import React, { useState } from 'react';
 import { css } from '@emotion/react';
 
 import { Tabs } from '../index';
 import { tokens } from '../../tokens';
 import { Paragraph } from '../../paragraph';
+import { mediaQuery } from '../../helpers';
 
 const wrapperStyle = css`
   padding-top: ${tokens.spacing.medium};
+  padding-left: ${tokens.spacing.small};
+  padding-right: ${tokens.spacing.small};
+
+  ${mediaQuery.aboveSmall} {
+    padding-left: ${tokens.spacing.medium};
+    padding-right: ${tokens.spacing.medium};
+  }
 `;
 
 function Story() {
-  const [activeTabIndex, setActiveTabIndex] = useState<React.Key>(0);
-
   return (
     <div css={wrapperStyle}>
-      <Tabs
-        activeTab={activeTabIndex}
-        onChange={(activeTab) => {
-          setActiveTabIndex(activeTab);
-        }}
-      >
-        <Tabs.Tab label="First Tab" data-testid="first-tab">
+      <Tabs activeTab={0}>
+        <Tabs.Tab label="First Tab">
           <Paragraph>First Tab Content</Paragraph>
         </Tabs.Tab>
-        <Tabs.Tab label="Second Tab" data-testid="second-tab">
+        <Tabs.Tab label="Second Tab With Long Label">
           <Paragraph>Second Tab Content</Paragraph>
         </Tabs.Tab>
-        <Tabs.Tab disabled label="Third Tab Disabled" data-testid="third-tab">
+        <Tabs.Tab disabled label="Disabled Third Tab">
           <Paragraph>Third Tab Content</Paragraph>
+        </Tabs.Tab>
+        <Tabs.Tab label="Fourth Tab With Long Label">
+          <Paragraph>Fourth Tab Content</Paragraph>
         </Tabs.Tab>
       </Tabs>
     </div>

--- a/src/tabs/__tests__/tabs-with-icons.story.tsx
+++ b/src/tabs/__tests__/tabs-with-icons.story.tsx
@@ -1,32 +1,25 @@
-import React, { useState } from 'react';
 import { css } from '@emotion/react';
 
 import { Tabs } from '../index';
 import { tokens } from '../../tokens';
 import { Paragraph } from '../../paragraph';
+import { Bell, Clock, Heart } from '../../icon';
 
 const wrapperStyle = css`
-  padding-top: ${tokens.spacing.medium};
+  padding: ${tokens.spacing.medium};
 `;
 
 function Story() {
-  const [activeTabIndex, setActiveTabIndex] = useState<React.Key>(0);
-
   return (
     <div css={wrapperStyle}>
-      <Tabs
-        activeTab={activeTabIndex}
-        onChange={(activeTab) => {
-          setActiveTabIndex(activeTab);
-        }}
-      >
-        <Tabs.Tab label="First Tab" data-testid="first-tab">
+      <Tabs activeTab={0}>
+        <Tabs.Tab icon={<Heart size="xsmall" />} label="First">
           <Paragraph>First Tab Content</Paragraph>
         </Tabs.Tab>
-        <Tabs.Tab label="Second Tab" data-testid="second-tab">
+        <Tabs.Tab icon={<Clock size="xsmall" />} label="Second">
           <Paragraph>Second Tab Content</Paragraph>
         </Tabs.Tab>
-        <Tabs.Tab disabled label="Third Tab Disabled" data-testid="third-tab">
+        <Tabs.Tab icon={<Bell size="xsmall" />} label="Third">
           <Paragraph>Third Tab Content</Paragraph>
         </Tabs.Tab>
       </Tabs>

--- a/src/tabs/__tests__/tabs.e2e.ts
+++ b/src/tabs/__tests__/tabs.e2e.ts
@@ -1,13 +1,25 @@
+const screenSizes: Record<string, [number, number]> = {
+  small: [375, 800],
+  medium: [768, 1024],
+  large: [1920, 1080],
+};
+
 describe('Tabs', () => {
   it('render tabs with one of them disabled', () => {
     cy.loadStory('tabs-basic');
     cy.get('main').findAllByRole('tab').should('have.length', 3);
   });
 
-  it(`renders correctly on small screen device`, () => {
-    cy.viewport(375, 800);
-    cy.loadStory('tabs-basic');
-    cy.get('main').findAllByRole('tab').should('have.length', 3);
+  describe('renders correctly', () => {
+    Object.keys(screenSizes).forEach((size) => {
+      const [width, height] = screenSizes[size];
+
+      it(`on ${size} screen device`, () => {
+        cy.viewport(width, height);
+        cy.loadStory('tabs-long');
+        cy.get('main').findAllByRole('tab').should('have.length', 4);
+      });
+    });
   });
 
   it('render inverted tabs with one of them disabled', () => {
@@ -18,6 +30,11 @@ describe('Tabs', () => {
   it('render tabs as links', () => {
     cy.loadStory('tabs-as-links');
     cy.get('main').find('a').should('have.length', 3);
+  });
+
+  it('render icons next to tab labels', () => {
+    cy.loadStory('tabs-with-icons');
+    cy.get('main').findAllByRole('tab').should('have.length', 3);
   });
 
   it('after tab is clicked, appropriate panel is displayed', () => {
@@ -66,3 +83,5 @@ describe('Tabs', () => {
     cy.get('main').findByText('Fourth Tab Content').should('exist');
   });
 });
+
+export {};

--- a/src/tabs/styles.ts
+++ b/src/tabs/styles.ts
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 
 import { tokens } from '../tokens';
-import { mediaQuery, hexToRgba } from '../helpers';
+import { hexToRgba } from '../helpers';
 
 type TabListStyleOptions = {
   isGradientMaskVisible: boolean;
@@ -12,9 +12,9 @@ export function tabListStyle({ isGradientMaskVisible }: TabListStyleOptions) {
     width: 100%;
     margin-bottom: ${tokens.spacing.medium};
 
-    /* Make tabs scrollable on mobile, while hiding scroll, and show gradient mask  */
+    /* Make tabs scrollable, while hiding scroll, and showing gradient mask  */
     mask-image: ${isGradientMaskVisible
-      ? 'linear-gradient(90deg, rgba(0, 0, 0, 1) 80%, rgba(0, 0, 0, 0))'
+      ? `linear-gradient(90deg, rgba(0, 0, 0, 1) calc(100% - ${tokens.spacing.xxlarge}), rgba(0, 0, 0, 0))`
       : 'none'};
     overflow-y: hidden;
     overflow-x: auto;
@@ -24,13 +24,6 @@ export function tabListStyle({ isGradientMaskVisible }: TabListStyleOptions) {
       display: none;
       width: 0;
       height: 0;
-    }
-
-    /* Turn off scrolling for bigger devices */
-    ${mediaQuery.aboveSmall} {
-      overflow-y: visible;
-      overflow-x: visible;
-      mask-image: none;
     }
   `;
 }
@@ -44,15 +37,9 @@ export function tabsWrapper({ inverted }: TabsWrapperStyleOptions) {
     display: inline-flex;
     min-width: 100%;
     padding-left: 0;
-    padding-right: 64px;
+    padding-right: ${tokens.spacing.xxlarge};
     border-bottom: ${tokens.borderWidth.medium} solid
       ${hexToRgba(inverted ? tokens.colors.white : tokens.colors.navy, 0.15)};
-
-    ${mediaQuery.aboveSmall} {
-      display: flex;
-      padding-left: 0;
-      padding-right: 0;
-    }
   `;
 }
 

--- a/src/tabs/styles.ts
+++ b/src/tabs/styles.ts
@@ -112,7 +112,7 @@ export function tabStyle({
 
     ${isFocusVisible &&
     css`
-      box-shadow: 0 0 0 2px ${tokens.colors.blueDark};
+      box-shadow: inset 0 0 0 2px ${tokens.colors.blueDark};
     `}
   `;
 }


### PR DESCRIPTION
# Scrollable Tabs on all devices

## [WF-597](https://datacamp.atlassian.net/browse/WF-597)

## Changes

### 🔧 Minor Changes

- Make `Tabs` scrollable on all device sizes (previously it was only on mobile). The gradient mask is shown when all tabs combined width is longer than their container. In future for desktop most likely we will implement either scroll arrows or show more button.
- Update focus style of `Tabs.Tab` to be more compact because of changes required to container overflow CSS property.

## Screenshot(s):

Large desktop:
<img width="1327" alt="Screenshot 2022-06-06 at 16 27 40" src="https://user-images.githubusercontent.com/20565536/172182565-7fed9390-40e5-4360-a257-7d43dd34c6e2.png">

Tablet & small desktop:
<img width="762" alt="Screenshot 2022-06-06 at 16 28 05" src="https://user-images.githubusercontent.com/20565536/172182597-e509b8b5-06fe-4afb-bfc3-4525bfaed553.png">

Mobile: 
<img width="369" alt="Screenshot 2022-06-06 at 16 28 16" src="https://user-images.githubusercontent.com/20565536/172182627-990014ed-296a-46a2-831e-e68de3f73dc3.png">

Updated focus style:
<img width="486" alt="Screenshot 2022-06-06 at 16 28 33" src="https://user-images.githubusercontent.com/20565536/172182664-b5a6e0ff-dc27-45f9-b279-46dffdea7575.png">

