### PR TITLE
TextArea spacing adjustments

### DIFF
--- a/src/text-area/__tests__/__snapshots__/text-area.spec.tsx.snap
+++ b/src/text-area/__tests__/__snapshots__/text-area.spec.tsx.snap
@@ -43,7 +43,7 @@ exports[`TextArea renders all supporting elements to make auto-grow work 1`] = `
   font-size: 14px;
   color: #05192D;
   background-color: #FFFFFF;
-  padding: 8px 12px;
+  padding: 6px 12px;
 }
 
 .emotion-2:disabled {
@@ -85,6 +85,8 @@ exports[`TextArea renders all supporting elements to make auto-grow work 1`] = `
   border: 1px solid #848C92;
   border-radius: 4px;
   outline: 0;
+  font-size: 14px;
+  padding: 6px 12px;
   grid-area: 1/1/2/2;
   visibility: hidden;
   white-space: pre-wrap;
@@ -156,7 +158,7 @@ exports[`TextArea renders snapshot 1`] = `
   font-size: 14px;
   color: #05192D;
   background-color: #FFFFFF;
-  padding: 8px 12px;
+  padding: 6px 12px;
 }
 
 .emotion-1:disabled {
@@ -233,7 +235,7 @@ exports[`TextArea renders snapshot of disabled 1`] = `
   font-size: 14px;
   color: #05192D;
   background-color: #FFFFFF;
-  padding: 8px 12px;
+  padding: 6px 12px;
 }
 
 .emotion-1:disabled {
@@ -310,7 +312,7 @@ exports[`TextArea renders snapshot of inverted 1`] = `
   font-size: 14px;
   color: #FFFFFF;
   background-color: #213147;
-  padding: 8px 12px;
+  padding: 6px 12px;
 }
 
 .emotion-1:disabled {
@@ -386,7 +388,7 @@ exports[`TextArea renders snapshot of required with error 1`] = `
   font-size: 14px;
   color: #05192D;
   background-color: #FFFFFF;
-  padding: 8px 12px;
+  padding: 6px 12px;
   border-color: #DD3400;
   box-shadow: 0 0 0 1px #DD3400;
 }
@@ -464,7 +466,7 @@ exports[`TextArea renders snapshot when character count is displayed 1`] = `
   font-size: 14px;
   color: #05192D;
   background-color: #FFFFFF;
-  padding: 8px 12px;
+  padding: 6px 12px;
 }
 
 .emotion-1:disabled {
@@ -577,7 +579,7 @@ exports[`renders snapshot of size large 1`] = `
   font-size: 14px;
   color: #05192D;
   background-color: #FFFFFF;
-  padding: 8px 12px;
+  padding: 6px 12px;
 }
 
 .emotion-1:disabled {
@@ -653,7 +655,7 @@ exports[`renders snapshot of size medium 1`] = `
   font-size: 14px;
   color: #05192D;
   background-color: #FFFFFF;
-  padding: 8px 12px;
+  padding: 6px 12px;
 }
 
 .emotion-1:disabled {
@@ -729,7 +731,7 @@ exports[`renders snapshot of size small 1`] = `
   font-size: 12px;
   color: #05192D;
   background-color: #FFFFFF;
-  padding: 8px 6px;
+  padding: 4px 6px;
 }
 
 .emotion-1:disabled {

--- a/src/text-area/__tests__/text-area-single-row.story.tsx
+++ b/src/text-area/__tests__/text-area-single-row.story.tsx
@@ -1,0 +1,27 @@
+import { css } from '@emotion/react';
+
+import { tokens } from '../../tokens';
+import { TextArea } from '../../text-area';
+import { Input } from '../../input';
+
+const wrapperStyle = css`
+  display: grid;
+  grid-template-columns: 300px 300px;
+  gap: ${tokens.spacing.medium};
+  padding: ${tokens.spacing.medium};
+`;
+
+function Story() {
+  return (
+    <div css={wrapperStyle}>
+      <Input placeholder="Small input" size="small" />
+      <TextArea placeholder="Small text area" rows={1} size="small" />
+      <Input placeholder="Medium input" size="medium" />
+      <TextArea placeholder="Medium text area" rows={1} size="medium" />
+      <Input placeholder="Large input" size="large" />
+      <TextArea placeholder="Large text area" rows={1} size="large" />
+    </div>
+  );
+}
+
+export default Story;

--- a/src/text-area/__tests__/text-area.e2e.ts
+++ b/src/text-area/__tests__/text-area.e2e.ts
@@ -43,6 +43,12 @@ describe('TextArea', () => {
     cy.get('main').findByText('9 / 20').should('exist');
   });
 
+  it('renders identical to regular input, when only 1 row is specified', () => {
+    cy.loadStory('text-area-single-row');
+    cy.get('main').find('textarea').should('have.length', 3);
+    cy.get('main').find('input').should('have.length', 3);
+  });
+
   it('if max lenght limit is specified, show only that many characters', () => {
     cy.loadStory('text-area-character-count');
     cy.get('main')

--- a/src/text-area/auto-grow.tsx
+++ b/src/text-area/auto-grow.tsx
@@ -1,19 +1,24 @@
 import React from 'react';
 
+import TextArea from './text-area';
 import { growWrapperStyle, fauxGrowElementStyle } from './styles';
 
 type AutoGrowProps = {
   value: React.TextareaHTMLAttributes<HTMLTextAreaElement>['value'];
+  size: NonNullable<React.ComponentProps<typeof TextArea>['size']>;
   autoGrow: boolean;
   children: JSX.Element;
 };
 
 // Add space at the end of faux element content to prevent jumping
-function AutoGrow({ value, autoGrow, children }: AutoGrowProps) {
+function AutoGrow({ value, size, autoGrow, children }: AutoGrowProps) {
   return autoGrow ? (
     <div css={growWrapperStyle()}>
       {children}
-      <div aria-hidden="true" css={fauxGrowElementStyle()}>{`${value} `}</div>
+      <div
+        aria-hidden="true"
+        css={fauxGrowElementStyle({ size })}
+      >{`${value} `}</div>
     </div>
   ) : (
     children

--- a/src/text-area/styles.ts
+++ b/src/text-area/styles.ts
@@ -9,15 +9,18 @@ import TextArea from './text-area';
 const sizeMap = {
   small: {
     fontSize: tokens.fontSizes.small,
-    spacing: '6px',
+    spacingVertical: '4px',
+    spacingHorizontal: '6px',
   },
   medium: {
     fontSize: tokens.fontSizes.medium,
-    spacing: '12px',
+    spacingVertical: '6px',
+    spacingHorizontal: '12px',
   },
   large: {
     fontSize: tokens.fontSizes.medium,
-    spacing: '12px',
+    spacingVertical: '6px',
+    spacingHorizontal: '12px',
   },
 } as const;
 
@@ -104,7 +107,7 @@ export function textAreaStyle({
       ? tokens.colors.navyLight
       : tokens.colors.white};
 
-    padding: ${tokens.spacing.small} ${sizeMap[size].spacing};
+    padding: ${sizeMap[size].spacingVertical} ${sizeMap[size].spacingHorizontal};
 
     &::placeholder {
       opacity: 1;

--- a/src/text-area/styles.ts
+++ b/src/text-area/styles.ts
@@ -8,18 +8,21 @@ import TextArea from './text-area';
 
 const sizeMap = {
   small: {
+    sizing: tokens.sizing.small,
     fontSize: tokens.fontSizes.small,
     spacingVertical: '4px',
     spacingHorizontal: '6px',
   },
   medium: {
+    sizing: tokens.sizing.medium,
     fontSize: tokens.fontSizes.medium,
     spacingVertical: '6px',
     spacingHorizontal: '12px',
   },
   large: {
+    sizing: tokens.sizing.large,
     fontSize: tokens.fontSizes.medium,
-    spacingVertical: '6px',
+    spacingVertical: '12px',
     spacingHorizontal: '12px',
   },
 } as const;
@@ -99,9 +102,8 @@ export function textAreaStyle({
 }: TextAreaStyleOptions) {
   return css`
     ${textAreaBaseStyle}
-    font-size: ${size === 'large'
-      ? sizeMap.medium.fontSize
-      : sizeMap[size].fontSize};
+    min-height: ${sizeMap[size].sizing};
+    font-size: ${sizeMap[size].fontSize};
     color: ${inverted ? tokens.colors.white : tokens.colors.navy};
     background-color: ${inverted
       ? tokens.colors.navyLight
@@ -137,9 +139,7 @@ type FauxGrowElementStyleOptions = {
 export function fauxGrowElementStyle({ size }: FauxGrowElementStyleOptions) {
   return css`
     ${textAreaBaseStyle}
-    font-size: ${size === 'large'
-      ? sizeMap.medium.fontSize
-      : sizeMap[size].fontSize};
+    font-size: ${sizeMap[size].fontSize};
     padding: ${sizeMap[size].spacingVertical} ${sizeMap[size].spacingHorizontal};
     grid-area: 1 / 1 / 2 / 2;
     visibility: hidden;

--- a/src/text-area/styles.ts
+++ b/src/text-area/styles.ts
@@ -130,9 +130,17 @@ export function growWrapperStyle() {
   `;
 }
 
-export function fauxGrowElementStyle() {
+type FauxGrowElementStyleOptions = {
+  size: NonNullable<React.ComponentProps<typeof TextArea>['size']>;
+};
+
+export function fauxGrowElementStyle({ size }: FauxGrowElementStyleOptions) {
   return css`
     ${textAreaBaseStyle}
+    font-size: ${size === 'large'
+      ? sizeMap.medium.fontSize
+      : sizeMap[size].fontSize};
+    padding: ${sizeMap[size].spacingVertical} ${sizeMap[size].spacingHorizontal};
     grid-area: 1 / 1 / 2 / 2;
     visibility: hidden;
     white-space: pre-wrap;

--- a/src/text-area/text-area-internal.tsx
+++ b/src/text-area/text-area-internal.tsx
@@ -72,7 +72,7 @@ function TextAreaInternal(
   }
 
   return (
-    <AutoGrow {...{ value, autoGrow }}>
+    <AutoGrow {...{ value, autoGrow, size }}>
       <div css={textAreaWrapper({ isFocused, autoGrow })}>
         <textarea
           {...restProps}


### PR DESCRIPTION
# TextArea sizes adjustments

## [WF-\*](https://datacamp.atlassian.net/browse/WF-*)

## Changes

### 🔧 Minor Changes

- Adjusted spacings so when `TextArea` is single row only it looks identical to regular `Input`.
- Properly synced auto grow wrapper with text area content. It never worked correctly - now it is more apparent with different sizings, before it was barely noticeable.

## Screenshot(s):

Inputs and TextAreas next to each other:
<img width="839" alt="Screenshot 2022-06-08 at 13 58 56" src="https://user-images.githubusercontent.com/20565536/172614010-85bedf8c-0b05-44b1-b568-8a8ba3366080.png">

Auto grow working properly:
<img width="830" alt="Screenshot 2022-06-08 at 13 59 26" src="https://user-images.githubusercontent.com/20565536/172614051-bf0cc4d5-23f6-4be9-b742-cfdc702df133.png">

