### PR TITLE
WF-621 - Loader rendering issue in safari

### DIFF
--- a/src/loader/__tests__/__snapshots__/loader.spec.tsx.snap
+++ b/src/loader/__tests__/__snapshots__/loader.spec.tsx.snap
@@ -3,25 +3,25 @@
 exports[`Loader renders a loader 1`] = `
 @keyframes animation-0 {
   0%, 6% {
-    -webkit-clip-path: polygon(0% -12%, 0% -12%, 169% 63%, 169% 63%);
-    clip-path: polygon(0% -12%, 0% -12%, 169% 63%, 169% 63%);
+    -webkit-clip-path: polygon(0% -12%, 0% -12%, 169% 65.5%, 169% 65.5%);
+    clip-path: polygon(0% -12%, 0% -12%, 169% 65.5%, 169% 65.5%);
   }
 
   100% {
-    -webkit-clip-path: polygon(0% -12%, 0% 308%, 169% 383%, 169% 63%);
-    clip-path: polygon(0% -12%, 0% 308%, 169% 383%, 169% 63%);
+    -webkit-clip-path: polygon(0% -12%, 0% 308%, 169% 383%, 169% 65.5%);
+    clip-path: polygon(0% -12%, 0% 308%, 169% 383%, 169% 65.5%);
   }
 }
 
 @keyframes animation-1 {
   0%, 71% {
-    -webkit-clip-path: polygon(0% 0%, 0% 78.5%, 100% 34.5%, 100% -44%);
-    clip-path: polygon(0% 0%, 0% 78.5%, 100% 34.5%, 100% -44%);
+    -webkit-clip-path: polygon(0% 0%, 0% 78.5%, 100% 34.5%, 100% -30%);
+    clip-path: polygon(0% 0%, 0% 78.5%, 100% 34.5%, 100% -30%);
   }
 
   96%, 100% {
-    -webkit-clip-path: polygon(0% 0%, 0% 140%, 100% 96%, 100% -44%);
-    clip-path: polygon(0% 0%, 0% 140%, 100% 96%, 100% -44%);
+    -webkit-clip-path: polygon(0% 0%, 0% 140%, 100% 96%, 100% -30%);
+    clip-path: polygon(0% 0%, 0% 140%, 100% 96%, 100% -30%);
   }
 }
 
@@ -32,13 +32,14 @@ exports[`Loader renders a loader 1`] = `
 }
 
 .emotion-0 {
-  display: block;
   -webkit-animation: animation-0 cubic-bezier(0.65, 0, 0.55, 1) 2s infinite alternate;
   animation: animation-0 cubic-bezier(0.65, 0, 0.55, 1) 2s infinite alternate;
   will-change: clip-path;
 }
 
 .emotion-1 {
+  -webkit-clip-path: polygon(-0.1% -10%, 169% 65%, -0.1% 139%);
+  clip-path: polygon(-0.1% -10%, 169% 65%, -0.1% 139%);
   -webkit-animation: animation-1 cubic-bezier(0, 0, 0.85, 1) 2s infinite alternate;
   animation: animation-1 cubic-bezier(0, 0, 0.85, 1) 2s infinite alternate;
   will-change: clip-path;
@@ -46,8 +47,10 @@ exports[`Loader renders a loader 1`] = `
 
 .emotion-2 {
   display: block;
-  -webkit-clip-path: polygon(-0.1% -10%, 169% 65%, -0.1% 139%);
-  clip-path: polygon(-0.1% -10%, 169% 65%, -0.1% 139%);
+  stroke: #000820;
+}
+
+.emotion-3 {
   -webkit-animation: animation-2 cubic-bezier(0.65, 0, 0.55, 1) 2s infinite alternate;
   animation: animation-2 cubic-bezier(0.65, 0, 0.55, 1) 2s infinite alternate;
   stroke-dasharray: 9800;
@@ -67,9 +70,9 @@ exports[`Loader renders a loader 1`] = `
       viewBox="0 0 2640 3444"
     >
       <path
+        class="emotion-3"
         d="M0 0 M2569 1056L143 2447V149l1175 673v1867l1248 715"
         fill="none"
-        stroke="#000820"
         stroke-linejoin="round"
         stroke-width="300"
       />
@@ -81,25 +84,25 @@ exports[`Loader renders a loader 1`] = `
 exports[`Loader renders snapshot of inverted 1`] = `
 @keyframes animation-0 {
   0%, 6% {
-    -webkit-clip-path: polygon(0% -12%, 0% -12%, 169% 63%, 169% 63%);
-    clip-path: polygon(0% -12%, 0% -12%, 169% 63%, 169% 63%);
+    -webkit-clip-path: polygon(0% -12%, 0% -12%, 169% 65.5%, 169% 65.5%);
+    clip-path: polygon(0% -12%, 0% -12%, 169% 65.5%, 169% 65.5%);
   }
 
   100% {
-    -webkit-clip-path: polygon(0% -12%, 0% 308%, 169% 383%, 169% 63%);
-    clip-path: polygon(0% -12%, 0% 308%, 169% 383%, 169% 63%);
+    -webkit-clip-path: polygon(0% -12%, 0% 308%, 169% 383%, 169% 65.5%);
+    clip-path: polygon(0% -12%, 0% 308%, 169% 383%, 169% 65.5%);
   }
 }
 
 @keyframes animation-1 {
   0%, 71% {
-    -webkit-clip-path: polygon(0% 0%, 0% 78.5%, 100% 34.5%, 100% -44%);
-    clip-path: polygon(0% 0%, 0% 78.5%, 100% 34.5%, 100% -44%);
+    -webkit-clip-path: polygon(0% 0%, 0% 78.5%, 100% 34.5%, 100% -30%);
+    clip-path: polygon(0% 0%, 0% 78.5%, 100% 34.5%, 100% -30%);
   }
 
   96%, 100% {
-    -webkit-clip-path: polygon(0% 0%, 0% 140%, 100% 96%, 100% -44%);
-    clip-path: polygon(0% 0%, 0% 140%, 100% 96%, 100% -44%);
+    -webkit-clip-path: polygon(0% 0%, 0% 140%, 100% 96%, 100% -30%);
+    clip-path: polygon(0% 0%, 0% 140%, 100% 96%, 100% -30%);
   }
 }
 
@@ -110,13 +113,14 @@ exports[`Loader renders snapshot of inverted 1`] = `
 }
 
 .emotion-0 {
-  display: block;
   -webkit-animation: animation-0 cubic-bezier(0.65, 0, 0.55, 1) 2s infinite alternate;
   animation: animation-0 cubic-bezier(0.65, 0, 0.55, 1) 2s infinite alternate;
   will-change: clip-path;
 }
 
 .emotion-1 {
+  -webkit-clip-path: polygon(-0.1% -10%, 169% 65%, -0.1% 139%);
+  clip-path: polygon(-0.1% -10%, 169% 65%, -0.1% 139%);
   -webkit-animation: animation-1 cubic-bezier(0, 0, 0.85, 1) 2s infinite alternate;
   animation: animation-1 cubic-bezier(0, 0, 0.85, 1) 2s infinite alternate;
   will-change: clip-path;
@@ -124,8 +128,10 @@ exports[`Loader renders snapshot of inverted 1`] = `
 
 .emotion-2 {
   display: block;
-  -webkit-clip-path: polygon(-0.1% -10%, 169% 65%, -0.1% 139%);
-  clip-path: polygon(-0.1% -10%, 169% 65%, -0.1% 139%);
+  stroke: #FFFFFF;
+}
+
+.emotion-3 {
   -webkit-animation: animation-2 cubic-bezier(0.65, 0, 0.55, 1) 2s infinite alternate;
   animation: animation-2 cubic-bezier(0.65, 0, 0.55, 1) 2s infinite alternate;
   stroke-dasharray: 9800;
@@ -145,9 +151,9 @@ exports[`Loader renders snapshot of inverted 1`] = `
       viewBox="0 0 2640 3444"
     >
       <path
+        class="emotion-3"
         d="M0 0 M2569 1056L143 2447V149l1175 673v1867l1248 715"
         fill="none"
-        stroke="#FFFFFF"
         stroke-linejoin="round"
         stroke-width="300"
       />

--- a/src/loader/keyframes.ts
+++ b/src/loader/keyframes.ts
@@ -8,18 +8,18 @@ export const stroke = keyframes`
 
 export const loaderStartMask = keyframes`
   0%, 6% {
-    clip-path: polygon(0% -12%, 0% -12%, 169% 63%, 169% 63%);
+    clip-path: polygon(0% -12%, 0% -12%, 169% 65.5%, 169% 65.5%);
   }
   100% {
-    clip-path: polygon(0% -12%, 0% 308%, 169% 383%, 169% 63%);
+    clip-path: polygon(0% -12%, 0% 308%, 169% 383%, 169% 65.5%);
   }
 `;
 
 export const loaderEndMask = keyframes`
   0%, 71% {
-    clip-path: polygon(0% 0%, 0% 78.5%, 100% 34.5%, 100% -44%);
+    clip-path: polygon(0% 0%, 0% 78.5%, 100% 34.5%, 100% -30%);
   }
   96%, 100% {
-    clip-path: polygon(0% 0%, 0% 140%, 100% 96%, 100% -44%);
+    clip-path: polygon(0% 0%, 0% 140%, 100% 96%, 100% -30%);
   }
 `;

--- a/src/loader/loader.tsx
+++ b/src/loader/loader.tsx
@@ -1,8 +1,11 @@
 import React from 'react';
 
-import { tokens } from '../tokens';
-
-import { loaderSvgStyle, loaderSvgWrapperStyle, wrapperStyle } from './styles';
+import {
+  loaderPathStyle,
+  loaderSvgStyle,
+  loaderSvgWrapperStyle,
+  wrapperStyle,
+} from './styles';
 
 type LoaderProps = {
   /* Whether the loader is inverted in color or not. */
@@ -18,11 +21,15 @@ function Loader({ inverted = false, ...restProps }: LoaderProps) {
       data-testid="loader-wrapper"
     >
       <div css={loaderSvgWrapperStyle}>
-        <svg viewBox="0 0 2640 3444" css={loaderSvgStyle} {...restProps}>
+        <svg
+          viewBox="0 0 2640 3444"
+          css={loaderSvgStyle({ inverted })}
+          {...restProps}
+        >
           <path
+            css={loaderPathStyle}
             d="M0 0 M2569 1056L143 2447V149l1175 673v1867l1248 715"
             fill="none"
-            stroke={inverted ? tokens.colors.white : tokens.colors.navyDark}
             strokeLinejoin="round"
             strokeWidth="300"
           ></path>

--- a/src/loader/styles.ts
+++ b/src/loader/styles.ts
@@ -1,17 +1,19 @@
 import { css } from '@emotion/react';
 
+import { tokens } from '../tokens';
+
+import Loader from './loader';
 import { loaderEndMask, loaderStartMask, stroke } from './keyframes';
 
 const animationSettings = '2s infinite alternate';
 
-type WrapperStyleProps = {
+type WrapperStyleOptions = {
   height: string;
   width: string;
 };
 
-export function wrapperStyle({ height, width }: WrapperStyleProps) {
+export function wrapperStyle({ height, width }: WrapperStyleOptions) {
   return css`
-    display: block;
     height: ${height};
     width: ${width};
     animation: ${loaderStartMask} cubic-bezier(0.65, 0, 0.55, 1)
@@ -21,13 +23,23 @@ export function wrapperStyle({ height, width }: WrapperStyleProps) {
 }
 
 export const loaderSvgWrapperStyle = css`
+  clip-path: polygon(-0.1% -10%, 169% 65%, -0.1% 139%);
   animation: ${loaderEndMask} cubic-bezier(0, 0, 0.85, 1) ${animationSettings};
   will-change: clip-path;
 `;
 
-export const loaderSvgStyle = css`
-  display: block;
-  clip-path: polygon(-0.1% -10%, 169% 65%, -0.1% 139%);
+type LoaderSvgStyleOptions = {
+  inverted: NonNullable<React.ComponentProps<typeof Loader>['inverted']>;
+};
+
+export function loaderSvgStyle({ inverted }: LoaderSvgStyleOptions) {
+  return css`
+    display: block;
+    stroke: ${inverted ? tokens.colors.white : tokens.colors.navyDark};
+  `;
+}
+
+export const loaderPathStyle = css`
   animation: ${stroke} cubic-bezier(0.65, 0, 0.55, 1) ${animationSettings};
   stroke-dasharray: 9800;
   stroke-dashoffset: 9800;


### PR DESCRIPTION
# Fix loader rendering issue in safari

## [WF-621](https://datacamp.atlassian.net/browse/WF-621)

## Changes

### 🔧 Minor Changes

- Fixed rendering issue of svg within loader in Safari browser

### ❓ Misc Changes

- Moved stroke property from path element to svg element, to solve issue with setting custom stroke value

## Screenshot(s):
![Screenshot 2022-07-13 at 12 04 47](https://user-images.githubusercontent.com/9938773/178719378-f6150e39-565a-4bab-bed4-7d17c82f201a.png)

